### PR TITLE
Added default serial port for Teensy 3.0/3.1/3.2 and Teensy LC

### DIFF
--- a/src/midi_Defs.h
+++ b/src/midi_Defs.h
@@ -214,7 +214,7 @@ struct RPN
 #define MIDI_CREATE_INSTANCE(Type, SerialPort, Name)                            \
     midi::MidiInterface<Type> Name((Type&)SerialPort);
 
-#if defined(ARDUINO_SAM_DUE) || defined(USBCON)
+#if defined(ARDUINO_SAM_DUE) || defined(USBCON) || defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__)
     // Leonardo, Due and other USB boards use Serial1 by default.
     #define MIDI_CREATE_DEFAULT_INSTANCE()                                      \
         MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, MIDI);


### PR DESCRIPTION
The Teensy 3.0/3.1/3.2 boards should also default to using Serial1 as that is the first hardware UART as opposed to a USB serial device.