### PR TITLE
Fix some compiler warnings

### DIFF
--- a/builder/CMakeLists.txt
+++ b/builder/CMakeLists.txt
@@ -8,11 +8,26 @@ macro(setup_builder)
 
     include_directories(${ROOT_SOURCE_DIR})
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W -Wshadow -Wunused-variable -Wunused-parameter -Wunused-function -Wunused -Wno-system-headers -Wno-deprecated -Woverloaded-virtual")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+      -Wall                 \
+      -W                    \
+      -Wshadow              \
+      -Wunused-variable     \
+      -Wunused-parameter    \
+      -Wunused-function     \
+      -Wunused              \
+      -Wno-system-headers   \
+      -Wno-deprecated       \
+      -Woverloaded-virtual  \
+    ")
     if (BUILDER_ENABLE_PROFILING)
         set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
         set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage")
     endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+endmacro()
+
+macro(increase_warning_level)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconversion -Wsign-conversion")
 endmacro()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+increase_warning_level()
+
 project(midi)
 
 add_library(midi STATIC

--- a/src/MIDI.cpp
+++ b/src/MIDI.cpp
@@ -95,7 +95,7 @@ unsigned decodeSysEx(const byte* inSysEx, byte* outData, unsigned inLength)
         else
         {
             const byte body = inSysEx[i];
-            const byte msb  = ((msbStorage >> byteIndex--) & 1) << 7;
+            const byte msb  = byte(((msbStorage >> byteIndex--) & 1) << 7);
             outData[count++] = msb | body;
         }
     }

--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -375,7 +375,7 @@ template<class SerialPort, class Settings>
 void MidiInterface<SerialPort, Settings>::sendTimeCodeQuarterFrame(DataByte inTypeNibble,
                                                                    DataByte inValuesNibble)
 {
-    const byte data = (((inTypeNibble & 0x07) << 4) | (inValuesNibble & 0x0f));
+    const byte data = byte((((inTypeNibble & 0x07) << 4) | (inValuesNibble & 0x0f)));
     sendTimeCodeQuarterFrame(data);
 }
 
@@ -620,7 +620,7 @@ template<class SerialPort, class Settings>
 StatusByte MidiInterface<SerialPort, Settings>::getStatus(MidiType inType,
                                                           Channel inChannel) const
 {
-    return ((byte)inType | ((inChannel - 1) & 0x0f));
+    return StatusByte(((byte)inType | ((inChannel - 1) & 0x0f)));
 }
 
 // -----------------------------------------------------------------------------
@@ -856,7 +856,7 @@ bool MidiInterface<SerialPort, Settings>::parse()
 
                         // Get length
                         mMessage.data1   = mPendingMessageIndex & 0xff; // LSB
-                        mMessage.data2   = mPendingMessageIndex >> 8;   // MSB
+                        mMessage.data2   = byte(mPendingMessageIndex >> 8);   // MSB
                         mMessage.channel = 0;
                         mMessage.valid   = true;
 
@@ -1116,7 +1116,7 @@ MidiType MidiInterface<SerialPort, Settings>::getTypeFromStatusByte(byte inStatu
 template<class SerialPort, class Settings>
 inline Channel MidiInterface<SerialPort, Settings>::getChannelFromStatusByte(byte inStatus)
 {
-    return (inStatus & 0x0f) + 1;
+    return Channel((inStatus & 0x0f) + 1);
 }
 
 template<class SerialPort, class Settings>
@@ -1221,7 +1221,7 @@ void MidiInterface<SerialPort, Settings>::launchCallback()
 
             // Occasional messages
         case TimeCodeQuarterFrame:  if (mTimeCodeQuarterFrameCallback != 0)  mTimeCodeQuarterFrameCallback(mMessage.data1);    break;
-        case SongPosition:          if (mSongPositionCallback != 0)          mSongPositionCallback((mMessage.data1 & 0x7f) | ((mMessage.data2 & 0x7f) << 7));    break;
+        case SongPosition:          if (mSongPositionCallback != 0)          mSongPositionCallback(unsigned((mMessage.data1 & 0x7f) | ((mMessage.data2 & 0x7f) << 7)));    break;
         case SongSelect:            if (mSongSelectCallback != 0)            mSongSelectCallback(mMessage.data1);    break;
         case TuneRequest:           if (mTuneRequestCallback != 0)           mTuneRequestCallback();    break;
 

--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -292,7 +292,7 @@ template<class SerialPort, class Settings>
 void MidiInterface<SerialPort, Settings>::sendPitchBend(int inPitchValue,
                                                         Channel inChannel)
 {
-    const unsigned bend = inPitchValue - MIDI_PITCHBEND_MIN;
+    const unsigned bend = unsigned(inPitchValue - int(MIDI_PITCHBEND_MIN));
     send(PitchBend, (bend & 0x7f), (bend >> 7) & 0x7f, inChannel);
 }
 


### PR DESCRIPTION
Here are some suggestions to fix compiler warnings for the following flags:
-Wconversion
-Wsign-conversion

I just fixed what popped up in my console so more might be coming up.
With this pull request I want to find out if you are interested in fixing those warnings and if you like this style of fixing them.