### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -77,8 +77,8 @@ setHandleSystemReset	KEYWORD2
 getTypeFromStatusByte	KEYWORD2
 getChannelFromStatusByte	KEYWORD2
 isChannelMessage	KEYWORD2
-encodeSysEx KEYWORD2
-decodeSysEx KEYWORD2
+encodeSysEx	KEYWORD2
+decodeSysEx	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords