### PR TITLE
Avoid overflowing UART output buffer

### DIFF
--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -333,9 +333,12 @@ void MidiInterface<SerialPort, Settings>::sendSysEx(unsigned inLength,
         mSerial.write(0xf0);
     }
 
-    for (unsigned i = 0; i < inLength; ++i)
+    for (unsigned i = 0; i < inLength; )
     {
-        mSerial.write(inArray[i]);
+        if (mSerial.availableForWrite() > 0) {
+            mSerial.write(inArray[i]);
+            i++;
+        }
     }
 
     if (writeBeginEndBytes)


### PR DESCRIPTION
When processing input from MIDIUSB, data is sometime lost when writing to the UART. Add check for free buffer space before writing to UART.