### PR TITLE
Fixed bug that Common & Realtime messages were not detected

### DIFF
--- a/src/midi_UsbTransport.hpp
+++ b/src/midi_UsbTransport.hpp
@@ -81,7 +81,7 @@ inline bool UsbTransport<BufferSize>::pollUsbMidi()
     {
         received = true;
 
-        switch (packet.header << 4)
+        switch (packet.byte1)
         {
                 // 3 bytes messages
             case midi::NoteOff:
@@ -112,11 +112,11 @@ inline bool UsbTransport<BufferSize>::pollUsbMidi()
                 mRxBuffer.write(packet.byte1);
                 break;
 
-                // Special cases
-                // case midi::SystemExclusive:
-                // case midi::TimeCodeQuarterFrame:
-                // case midi::SongPosition:
-                // case midi::SongSelect:
+            // Special cases
+            // case midi::SystemExclusive:
+            // case midi::TimeCodeQuarterFrame:
+            // case midi::SongPosition:
+            // case midi::SongSelect:
                 //   break;
 
             default:


### PR DESCRIPTION
This fixes a bug that System Common & System Realtime messages were not being detected. For all messages that are in the 0xF... range, the header after the <<4 is 0xF0. Changed the code so that it actually looks at the complete header (byte1)