### PR TITLE
Add support for ESP32 pins assignement

### DIFF
--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -86,6 +86,8 @@ void MidiInterface<SerialPort, Settings>::begin(Channel inChannel)
     // Initialise the Serial port
 #if defined(AVR_CAKE)
     mSerial. template open<Settings::BaudRate>();
+#elif defined(ARDUINO_ARCH_ESP32)
+    mSerial.begin(Settings::BaudRate, SERIAL_8N1, Settings::RxPin, Settings::TxPin);
 #else
     mSerial.begin(Settings::BaudRate);
 #endif

--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -71,6 +71,13 @@ struct DefaultSettings
     http://projectgus.github.io/hairless-midiserial/
     */
     static const long BaudRate = 31250;
+ 
+    /*! Add support for ESP32 pins assignement.
+    Without pins re-mapping Serial1 cannot be used on many ESP32 dev boards.
+    Default Serial1 pins (RX1=GPIO9 TX1=GPIO10) are mainly used for flash memory.
+    */
+    static const int8_t RxPin = -1;
+    static const int8_t TxPin = -1;
 
     /*! Maximum size of SysEx receivable. Decrease to save RAM if you don't expect
     to receive SysEx, or adjust accordingly.


### PR DESCRIPTION
Without pins re-mapping Serial1 cannot be used on many ESP32 dev boards