### PR TITLE
Extracted all Serial related code to a separate super class, so that MidiInterface can be used for other encodings (ipMIDI, AppleMIDI, ...)

### DIFF
--- a/src/MIDI.h
+++ b/src/MIDI.h
@@ -41,21 +41,29 @@ the hardware interface, meaning you can use HardwareSerial, SoftwareSerial
 or ak47's Uart classes. The only requirement is that the class implements
 the begin, read, write and available methods.
  */
-template<class SerialPort, class _Settings = DefaultSettings>
-class MidiInterface
+template<class _Settings = AbstractDefaultSettings>
+class AbstractMidiInterface
 {
 public:
     typedef _Settings Settings;
 
-public:
-    inline  MidiInterface(SerialPort& inSerial);
-    inline ~MidiInterface();
+protected:
+    inline AbstractMidiInterface();
 
-public:
-    void begin(Channel inChannel = 1);
+protected:
+    void begin(Channel inChannel);
 
-    // -------------------------------------------------------------------------
-    // MIDI Output
+	// -------------------------------------------------------------------------
+	// Abstract
+protected:
+	virtual void __beginWrite() {};
+	virtual void __write(byte) = 0;
+	virtual void __endWrite() {};
+	virtual int  __available() = 0;
+	virtual byte __read() = 0;
+
+	// -------------------------------------------------------------------------
+	// MIDI Output
 
 public:
     inline void sendNoteOn(DataByte inNoteNumber,
@@ -227,9 +235,6 @@ private:
     typedef Message<Settings::SysExMaxSize> MidiMessage;
 
 private:
-    SerialPort& mSerial;
-
-private:
     Channel         mInputChannel;
     StatusByte      mRunningStatus_RX;
     StatusByte      mRunningStatus_TX;
@@ -256,3 +261,5 @@ unsigned decodeSysEx(const byte* inSysEx, byte* outData,  unsigned inLength);
 END_MIDI_NAMESPACE
 
 #include "MIDI.hpp"
+
+#include "midi_serial.h"

--- a/src/MIDI.h
+++ b/src/MIDI.h
@@ -262,4 +262,4 @@ END_MIDI_NAMESPACE
 
 #include "MIDI.hpp"
 
-#include "midi_serial.h"
+#include "midi_Serial.h"

--- a/src/midi_Defs.h
+++ b/src/midi_Defs.h
@@ -51,6 +51,40 @@ BEGIN_MIDI_NAMESPACE
 #define MIDI_PITCHBEND_MIN      -8192
 #define MIDI_PITCHBEND_MAX      8191
 
+#define MIDI_SAMPLING_RATE_8KHZ			8000
+#define MIDI_SAMPLING_RATE_11KHZ		11025
+#define MIDI_SAMPLING_RATE_44K1HZ		44100
+#define MIDI_SAMPLING_RATE_48KHZ		48000
+#define MIDI_SAMPLING_RATE_88K2HZ		88200
+#define MIDI_SAMPLING_RATE_96KHZ		96000
+#define MIDI_SAMPLING_RATE_176K4HZ		176400
+#define MIDI_SAMPLING_RATE_192KHZ		192000
+#define MIDI_SAMPLING_RATE_DEFAULT		10000
+
+// MIDI Channel enumeration values
+#define MIDI_CHANNEL_1 0x00
+#define MIDI_CHANNEL_2 0x01
+#define MIDI_CHANNEL_3 0x02
+#define MIDI_CHANNEL_4 0x03
+#define MIDI_CHANNEL_5 0x04
+#define MIDI_CHANNEL_6 0x05
+#define MIDI_CHANNEL_7 0x06
+#define MIDI_CHANNEL_8 0x07
+#define MIDI_CHANNEL_9 0x08
+#define MIDI_CHANNEL_10 0x09
+#define MIDI_CHANNEL_11 0x0a
+#define MIDI_CHANNEL_12 0x0b
+#define MIDI_CHANNEL_13 0x0c
+#define MIDI_CHANNEL_14 0x0d
+#define MIDI_CHANNEL_15 0x0e
+#define MIDI_CHANNEL_16 0x0f
+#define MIDI_CHANNEL_BASE 0x10
+#define MIDI_CHANNEL_ALL 0x1f
+#define MIDI_CHANNEL_MASK 0x0f
+
+#define MIDI_LSB( v ) (v) & 0x7F
+#define MIDI_MSB( v ) ((v)>> 7)  & 0x7F
+
 // -----------------------------------------------------------------------------
 // Type definitions
 
@@ -203,36 +237,5 @@ struct RPN
         NullFunction            = (0x7f << 7) + 0x7f,
     };
 };
-
-// -----------------------------------------------------------------------------
-
-/*! \brief Create an instance of the library attached to a serial port.
- You can use HardwareSerial or SoftwareSerial for the serial port.
- Example: MIDI_CREATE_INSTANCE(HardwareSerial, Serial2, midi2);
- Then call midi2.begin(), midi2.read() etc..
- */
-#define MIDI_CREATE_INSTANCE(Type, SerialPort, Name)                            \
-    midi::MidiInterface<Type> Name((Type&)SerialPort);
-
-#if defined(ARDUINO_SAM_DUE) || defined(USBCON) || defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__)
-    // Leonardo, Due and other USB boards use Serial1 by default.
-    #define MIDI_CREATE_DEFAULT_INSTANCE()                                      \
-        MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, MIDI);
-#else
-    /*! \brief Create an instance of the library with default name, serial port
-    and settings, for compatibility with sketches written with pre-v4.2 MIDI Lib,
-    or if you don't bother using custom names, serial port or settings.
-    */
-    #define MIDI_CREATE_DEFAULT_INSTANCE()                                      \
-        MIDI_CREATE_INSTANCE(HardwareSerial, Serial,  MIDI);
-#endif
-
-/*! \brief Create an instance of the library attached to a serial port with
- custom settings.
- @see DefaultSettings
- @see MIDI_CREATE_INSTANCE
- */
-#define MIDI_CREATE_CUSTOM_INSTANCE(Type, SerialPort, Name, Settings)           \
-    midi::MidiInterface<Type, Settings> Name((Type&)SerialPort);
 
 END_MIDI_NAMESPACE

--- a/src/midi_Serial.h
+++ b/src/midi_Serial.h
@@ -1,0 +1,90 @@
+#pragma once
+
+BEGIN_MIDI_NAMESPACE
+
+struct DefaultSettings : AbstractDefaultSettings
+{
+	/*! Override the default MIDI baudrate to transmit over USB serial, to
+	a decoding program such as Hairless MIDI (set baudrate to 115200)\n
+	http://projectgus.github.io/hairless-midiserial/
+	*/
+	static const long BaudRate = 31250;
+};
+
+END_MIDI_NAMESPACE
+
+BEGIN_MIDI_NAMESPACE
+
+template<class SerialPort, class _Settings = DefaultSettings>
+class MidiInterface : public AbstractMidiInterface<DefaultSettings>
+{
+public:
+	typedef _Settings Settings; 
+
+public:
+	MidiInterface(SerialPort& inSerial)
+		: mSerial(inSerial) 
+	{
+	};
+
+	void begin(Channel inChannel = 1)
+	{
+		// Initialise the Serial port
+#if defined(AVR_CAKE)
+		mSerial. template open<Settings::BaudRate>();
+#else
+		mSerial.begin(Settings::BaudRate);
+#endif
+
+		AbstractMidiInterface<Settings>::begin(inChannel);
+	}
+
+	inline void __write(byte byte)
+	{
+		mSerial.write(byte);
+	};
+
+	inline byte __read()
+	{
+		return mSerial.read();
+	};
+
+	inline int __available()
+	{
+		return mSerial.available();
+	};
+
+private:
+	SerialPort& mSerial;
+};
+
+/*! \brief Create an instance of the library attached to a serial port.
+ You can use HardwareSerial or SoftwareSerial for the serial port.
+ Example: MIDI_CREATE_INSTANCE(HardwareSerial, Serial2, midi2);
+ Then call midi2.begin(), midi2.read() etc..
+ */
+#define MIDI_CREATE_INSTANCE(Type, SerialPort, Name)                            \
+	midi::MidiInterface<Type> Name((Type&)SerialPort);
+
+#if defined(ARDUINO_SAM_DUE) || defined(USBCON) || defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__)
+ // Leonardo, Due and other USB boards use Serial1 by default.
+#define MIDI_CREATE_DEFAULT_INSTANCE()                                      \
+	MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, MIDI);
+#else
+ /*! \brief Create an instance of the library with default name, serial port
+ and settings, for compatibility with sketches written with pre-v4.2 MIDI Lib,
+ or if you don't bother using custom names, serial port or settings.
+ */
+#define MIDI_CREATE_DEFAULT_INSTANCE()                                      \
+	MIDI_CREATE_INSTANCE(HardwareSerial, Serial, MIDI);
+#endif
+
+ /*! \brief Create an instance of the library attached to a serial port with
+  custom settings.
+  @see DefaultSettings
+  @see MIDI_CREATE_INSTANCE
+  */
+#define MIDI_CREATE_CUSTOM_INSTANCE(Type, SerialPort, Name, Settings)           \
+	midi::MidiInterface<Type, Settings> Name((Type&)SerialPort);
+
+END_MIDI_NAMESPACE

--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -46,7 +46,7 @@ BEGIN_MIDI_NAMESPACE
  MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, Serial2, midi, MySettings);
  \endcode
  */
-struct DefaultSettings
+struct AbstractDefaultSettings
 {
     /*! Running status enables short messages when sending multiple values
     of the same type and channel.\n
@@ -65,12 +65,6 @@ struct DefaultSettings
     a lot of traffic, but might induce MIDI Thru and treatment latency.
     */
     static const bool Use1ByteParsing = true;
-
-    /*! Override the default MIDI baudrate to transmit over USB serial, to
-    a decoding program such as Hairless MIDI (set baudrate to 115200)\n
-    http://projectgus.github.io/hairless-midiserial/
-    */
-    static const long BaudRate = 31250;
 
     /*! Maximum size of SysEx receivable. Decrease to save RAM if you don't expect
     to receive SysEx, or adjust accordingly.

--- a/test/unit-tests/tests/unit-tests_Settings.cpp
+++ b/test/unit-tests/tests/unit-tests_Settings.cpp
@@ -2,11 +2,10 @@
 
 BEGIN_MIDI_NAMESPACE
 
-const bool DefaultSettings::UseRunningStatus;
-const bool DefaultSettings::HandleNullVelocityNoteOnAsNoteOff;
-const bool DefaultSettings::Use1ByteParsing;
-const long DefaultSettings::BaudRate;
-const unsigned DefaultSettings::SysExMaxSize;
+const bool AbstractDefaultSettings::UseRunningStatus;
+const bool AbstractDefaultSettings::HandleNullVelocityNoteOnAsNoteOff;
+const bool AbstractDefaultSettings::Use1ByteParsing;
+const unsigned AbstractDefaultSettings::SysExMaxSize;
 
 END_MIDI_NAMESPACE
 
@@ -16,11 +15,10 @@ BEGIN_UNNAMED_NAMESPACE
 
 TEST(Settings, hasTheRightDefaultValues)
 {
-    EXPECT_EQ(midi::DefaultSettings::UseRunningStatus,                   false);
-    EXPECT_EQ(midi::DefaultSettings::HandleNullVelocityNoteOnAsNoteOff,  true);
-    EXPECT_EQ(midi::DefaultSettings::Use1ByteParsing,                    true);
-    EXPECT_EQ(midi::DefaultSettings::BaudRate,                           31250);
-    EXPECT_EQ(midi::DefaultSettings::SysExMaxSize,                       unsigned(128));
+    EXPECT_EQ(midi::AbstractDefaultSettings::UseRunningStatus,                   false);
+    EXPECT_EQ(midi::AbstractDefaultSettings::HandleNullVelocityNoteOnAsNoteOff,  true);
+    EXPECT_EQ(midi::AbstractDefaultSettings::Use1ByteParsing,                    true);
+    EXPECT_EQ(midi::AbstractDefaultSettings::SysExMaxSize,                       unsigned(128));
 }
 
 END_UNNAMED_NAMESPACE

--- a/test/unit-tests/tests/unit-tests_Settings.h
+++ b/test/unit-tests/tests/unit-tests_Settings.h
@@ -6,7 +6,7 @@
 BEGIN_UNIT_TESTS_NAMESPACE
 
 template<bool RunningStatus, bool OneByteParsing>
-struct VariableSettings : public midi::DefaultSettings
+struct VariableSettings : public midi::AbstractDefaultSettings
 {
     static const bool UseRunningStatus = RunningStatus;
     static const bool Use1ByteParsing  = OneByteParsing;


### PR DESCRIPTION
- Extracted all Serial related code to a separate super class, so that MidiInterface can be used for other encodings (ipMIDI, AppleMIDI, ...) (renamed to AbstractMidiInterface)
- **No impact** on existing code and examples (naming and creation macros remain the same
- Settings file split in 2: abstract part for all generic MIDI and other for serial MIDI (Baudrate)
- added midi_Serial for all serial specific code (suprisingly very small)
- Creation macros moved to midi_Serial.h (midi_Defs can be used by all encodings)

The above changes would dramatically increase (and reduce code size for mixed projects) the ability to create other encodings ([ipMIDI](https://github.com/lathoub/Arduino-ipMIDI), [AppleMIDI](https://github.com/lathoub/Arduino-AppleMIDI-Library), [BLE MIDI](https://github.com/lathoub/Arduino-BLE-MIDI))

The pull request has been made against the **master** branch, not against the **4.4.0** branch - but I'd be willing to do it against 4.4.0 if that is more appropriate.

Are these changes something you want to consider @franky47 ?

Lathoub
