### PR TITLE
Added missing if-statement for "useRunningStatus", causing a bug with a midi device

### DIFF
--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -911,24 +911,33 @@ bool MidiInterface<SerialPort, Settings>::parse()
             mMessage.valid = true;
 
             // Activate running status (if enabled for the received type)
-            switch (mMessage.type)
-            {
-                case NoteOff:
-                case NoteOn:
-                case AfterTouchPoly:
-                case ControlChange:
-                case ProgramChange:
-                case AfterTouchChannel:
-                case PitchBend:
-                    // Running status enabled: store it from received message
-                    mRunningStatus_RX = mPendingMessage[0];
-                    break;
+            if (Settings::UseRunningStatus) {
 
-                default:
+                switch (mMessage.type)
+                {
+	                    case NoteOff:
+	                    case NoteOn:
+	                    case AfterTouchPoly:
+	                    case ControlChange:
+	                    case ProgramChange:
+	                    case AfterTouchChannel:
+	                    case PitchBend:
+	                    // Running status enabled: store it from received message
+	                    mRunningStatus_RX = mPendingMessage[0];
+	                    break;
+
+                    default:
                     // No running status
-                    mRunningStatus_RX = InvalidType;
-                    break;
+	                    mRunningStatus_RX = InvalidType;
+	                    break;
+                }
             }
+
+            else {
+
+                mRunningStatus_RX = InvalidType;
+            }
+
             return true;
         }
         else

--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -915,13 +915,13 @@ bool MidiInterface<SerialPort, Settings>::parse()
 
                 switch (mMessage.type)
                 {
-	                    case NoteOff:
-	                    case NoteOn:
-	                    case AfterTouchPoly:
-	                    case ControlChange:
-	                    case ProgramChange:
-	                    case AfterTouchChannel:
-	                    case PitchBend:
+                    case NoteOff:
+                    case NoteOn:
+                    case AfterTouchPoly:
+                    case ControlChange:
+                    case ProgramChange:
+                    case AfterTouchChannel:
+                    case PitchBend:
 	                    // Running status enabled: store it from received message
 	                    mRunningStatus_RX = mPendingMessage[0];
 	                    break;


### PR DESCRIPTION
Added if statement asking for "useRunningStatus", as it caused a bug 
with a certain midi device, causing the arduino to resolve the same midi 
data multiple times. I think it was forgotten here, as the comment also 
suggests that this section is only for "Activate running status (if enabled...)"