### PR TITLE
fix bug in MIDI_CREATE_CUSTOM_INSTANCE

### DIFF
--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -38,12 +38,12 @@ BEGIN_MIDI_NAMESPACE
  macro to create your instance. The settings you don't override will keep their
  default value. Eg:
  \code{.cpp}
- struct MySettings : public midi::DefaultSettings
+ struct MySettings : public MIDI_NAMESPACE::DefaultSettings
  {
     static const unsigned SysExMaxSize = 1024; // Accept SysEx messages up to 1024 bytes long.
  };
 
- MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, Serial2, midi, MySettings);
+ MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, Serial2, MIDI, MySettings);
  \endcode
  */
 struct DefaultSettings

--- a/src/serialMIDI.h
+++ b/src/serialMIDI.h
@@ -91,6 +91,8 @@ private:
     SerialPort& mSerial;
 };
 
+END_MIDI_NAMESPACE
+
 /*! \brief Create an instance of the library attached to a serial port.
  You can use HardwareSerial or SoftwareSerial for the serial port.
  Example: MIDI_CREATE_INSTANCE(HardwareSerial, Serial2, midi2);
@@ -119,7 +121,5 @@ private:
  @see MIDI_CREATE_INSTANCE
  */
 #define MIDI_CREATE_CUSTOM_INSTANCE(Type, SerialPort, Name, Settings)           \
-    MIDI_NAMESPACE::SerialMIDI<Type, Settings> serial##Name(SerialPort);\
-    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type, Settings>> Name((MIDI_NAMESPACE::SerialMIDI<Type, Settings>&)serial##Name);
-
-END_MIDI_NAMESPACE
+    MIDI_NAMESPACE::SerialMIDI<Type> serial##Name(SerialPort);\
+    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type>, Settings> Name((MIDI_NAMESPACE::SerialMIDI<Type>&)serial##Name);


### PR DESCRIPTION
- MIDI Setting in MIDI_CREATE_CUSTOM_INSTANCE, but Setting for SerialMIDI
- MACRO outside of Namespace