### PR TITLE
Active sensingv2

### DIFF
--- a/examples/Hairless/Hairless.ino
+++ b/examples/Hairless/Hairless.ino
@@ -1,0 +1,30 @@
+#include <MIDI.h>
+USING_NAMESPACE_MIDI
+
+struct MySerialSettings : public MIDI_NAMESPACE::DefaultSerialSettings
+{
+  static const long BaudRate = 115200;
+};
+
+unsigned long t1 = millis();
+
+MIDI_NAMESPACE::SerialMIDI<HardwareSerial, MySerialSettings> serialMIDI(Serial1);
+MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<HardwareSerial, MySerialSettings>> MIDI((MIDI_NAMESPACE::SerialMIDI<HardwareSerial, MySerialSettings>&)serialMIDI);
+
+void setup()
+{
+  MIDI.begin(1);
+}
+
+void loop()
+{
+  MIDI.read();
+
+  // send a note every second
+  if ((millis() - t1) > 1000)
+  {
+    t1 = millis();
+
+    MIDI.sendNoteOn(random(1, 127), 55, 1);
+  }
+}

--- a/examples/ReceiverActiveSensing/ReceiverActiveSensing.ino
+++ b/examples/ReceiverActiveSensing/ReceiverActiveSensing.ino
@@ -1,0 +1,51 @@
+#include <MIDI.h>
+USING_NAMESPACE_MIDI
+
+struct MyMIDISettings : public MIDI_NAMESPACE::DefaultSettings
+{
+  // When setting UseReceiverActiveSensing to true, MIDI.read() *must* be called
+  // as often as possible (1000 / SenderActiveSensingPeriodicity per second).
+  //
+  // setting UseReceiverActiveSensing to true, adds 174 bytes of code.
+  //
+  // (Taken from a Roland MIDI Implementation Owner's manual)
+  // Once an Active Sensing message is received, the unit will begin monitoring
+  // the interval between all subsequent messages. If there is an interval of 420 ms
+  // or longer between messages while monitoring is active, the same processing
+  // as when All Sound Off, All Notes Off,and Reset All Controllers messages are
+  // received will be carried out. The unit will then stopmonitoring the message interval.
+
+  static const bool UseReceiverActiveSensing = true;
+
+  static const uint16_t ReceiverActiveSensingTimeout = 420;
+};
+
+MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, Serial1, MIDI, MyMIDISettings);
+
+void errorHandler(int8_t err)
+{
+  if (bitRead(err, ErrorActiveSensingTimeout))
+  {
+    MIDI.sendControlChange(AllSoundOff, 0, 1);
+    MIDI.sendControlChange(AllNotesOff, 0, 1);
+    MIDI.sendControlChange(ResetAllControllers, 0, 1);
+
+    digitalWrite(LED_BUILTIN, HIGH);
+  }
+  else
+    digitalWrite(LED_BUILTIN, LOW);
+}
+
+void setup()
+{
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+
+  MIDI.setHandleError(errorHandler);
+  MIDI.begin(1);
+}
+
+void loop()
+{
+  MIDI.read();
+}

--- a/examples/SenderActiveSensing/SenderActiveSensing.ino
+++ b/examples/SenderActiveSensing/SenderActiveSensing.ino
@@ -1,0 +1,58 @@
+#include <MIDI.h>
+USING_NAMESPACE_MIDI
+
+struct MyMIDISettings : public MIDI_NAMESPACE::DefaultSettings
+{
+  // When setting UseSenderActiveSensing to true, MIDI.read() *must* be called
+  // as often as possible (1000 / SenderActiveSensingPeriodicity per second). 
+  //
+  // setting UseSenderActiveSensing to true, adds 34 bytes of code.
+  //
+  // When using Active Sensing, call MIDI.read(); in the Arduino loop()
+  //
+  // from 'a' MIDI implementation manual: "Sent periodically"
+  // In the example here, a NoteOn is send every 1000ms (1s), ActiveSensing is
+  // send every 250ms after the last command.
+  // Logging the command will look like this:
+  //
+  // ...
+  // A.Sense  FE
+  // A.Sense  FE
+  // A.Sense  FE
+  // NoteOn   90 04 37 [E-2]
+  // A.Sense  FE
+  // A.Sense  FE
+  // A.Sense  FE
+  // NoteOn   90 04 37 [E-2]
+  // A.Sense  FE
+  // A.Sense  FE
+  // A.Sense  FE
+  // NoteOn   90 04 37 [E-2]
+  // ...
+
+  static const bool UseSenderActiveSensing = true;
+
+  static const uint16_t SenderActiveSensingPeriodicity = 250;
+};
+
+unsigned long t1 = millis();
+
+MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, Serial1, MIDI, MyMIDISettings);
+
+void setup()
+{
+  MIDI.begin(1);
+}
+
+void loop()
+{
+  MIDI.read();
+
+  // send a note every second
+  if ((millis() - t1) > 1000)
+  {
+    t1 = millis();
+
+    MIDI.sendNoteOn(random(1, 127), 55, 1);
+  }
+}

--- a/src/MIDI.h
+++ b/src/MIDI.h
@@ -282,7 +282,7 @@ private:
     MidiMessage     mMessage;
     unsigned long   mLastMessageSentTime;
     unsigned long   mLastMessageReceivedTime;
-    bool            mReceiverActiveSensingActivated;
+    bool            mReceiverActiveSensingActive;
     int8_t          mLastError;
 
 private:

--- a/src/MIDI.h
+++ b/src/MIDI.h
@@ -282,7 +282,6 @@ private:
     MidiMessage     mMessage;
     unsigned long   mLastMessageSentTime;
     unsigned long   mLastMessageReceivedTime;
-    unsigned long   mSenderActiveSensingPeriodicity;
     bool            mReceiverActiveSensingActivated;
     int8_t          mLastError;
 

--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -44,11 +44,9 @@ inline MidiInterface<Transport, Settings, Platform>::MidiInterface(Transport& in
     , mThruFilterMode(Thru::Full)
     , mLastMessageSentTime(0)
     , mLastMessageReceivedTime(0)
-    , mSenderActiveSensingPeriodicity(0)
     , mReceiverActiveSensingActivated(false)
     , mLastError(0)
 {
-        mSenderActiveSensingPeriodicity = Settings::SenderActiveSensingPeriodicity;
 }
 
 /*! \brief Destructor for MidiInterface.
@@ -720,7 +718,7 @@ inline bool MidiInterface<Transport, Settings, Platform>::read(Channel inChannel
     // assume that the connection has been terminated. At
     // termination, the receiver will turn off all voices and return to
     // normal (non- active sensing) operation.
-    if (Settings::UseSenderActiveSensing && (mSenderActiveSensingPeriodicity > 0) && (Platform::now() - mLastMessageSentTime) > mSenderActiveSensingPeriodicity)
+    if (Settings::UseSenderActiveSensing && (Platform::now() - mLastMessageSentTime) > Settings::SenderActiveSensingPeriodicity)
     {
         sendActiveSensing();
         mLastMessageSentTime = Platform::now();
@@ -1384,7 +1382,7 @@ inline void MidiInterface<Transport, Settings, Platform>::turnThruOff()
 template<class Transport, class Settings, class Platform>
 inline void MidiInterface<Transport, Settings, Platform>::UpdateLastSentTime()
 {
-    if (Settings::UseSenderActiveSensing && mSenderActiveSensingPeriodicity)
+    if (Settings::UseSenderActiveSensing)
         mLastMessageSentTime = Platform::now();
 }
 

--- a/src/midi_Defs.h
+++ b/src/midi_Defs.h
@@ -46,10 +46,6 @@ BEGIN_MIDI_NAMESPACE
 #define MIDI_PITCHBEND_MIN      -8192
 #define MIDI_PITCHBEND_MAX      8191
 
-/*! Receiving Active Sensing 
-*/
-static const uint16_t ActiveSensingTimeout = 300;
-
 // -----------------------------------------------------------------------------
 // Type definitions
 

--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -75,6 +75,7 @@ struct DefaultSettings
     /*! Global switch to turn on/off sender ActiveSensing
     Set to true to send ActiveSensing
     Set to false will not send ActiveSensing message (will also save memory)
+    as often as possible (1000 / SenderActiveSensingPeriodicity per second).
     */
     static const bool UseSenderActiveSensing = false;
 
@@ -95,10 +96,8 @@ struct DefaultSettings
 
     Typical value is 250 (ms) - an Active Sensing command is send every 250ms.
     (All Roland devices send Active Sensing every 250ms)
-
-    Setting this field to 0 will disable sending MIDI active sensing.
     */
-    static const uint16_t SenderActiveSensingPeriodicity = 0;
+    static const uint16_t SenderActiveSensingPeriodicity = 250;
 };
 
 END_MIDI_NAMESPACE

--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -74,16 +74,14 @@ struct DefaultSettings
 
     /*! Global switch to turn on/off sender ActiveSensing
     Set to true to send ActiveSensing
-    Set to false will not send ActiveSensing message (will also save memory)
-    as often as possible (1000 / SenderActiveSensingPeriodicity per second).
+    /*! Global switch to turn on/off sending and receiving ActiveSensing
+    Set to true to activate ActiveSensing
+    Set to false will not send/receive ActiveSensing message (will also save 236 bytes of memory)
+
+    When setting UseActiveSensing to true, MIDI.read() *must* be called
+    as often as possible (1000 / ActiveSensingPeriodicity per second).
     */
     static const bool UseSenderActiveSensing = false;
-
-    /*! Global switch to turn on/off receiver ActiveSensing
-    Set to true to check for message timeouts (via ErrorCallback)
-    Set to false will not check if chained device are still alive (if they use ActiveSensing) (will also save memory)
-    */
-    static const bool UseReceiverActiveSensing = false;
 
     /*! Active Sensing is intended to be sent
     repeatedly by the sender to tell the receiver that a connection is alive. Use
@@ -95,9 +93,20 @@ struct DefaultSettings
     normal (non- active sensing) operation.
 
     Typical value is 250 (ms) - an Active Sensing command is send every 250ms.
-    (All Roland devices send Active Sensing every 250ms)
+    (Most Roland devices send Active Sensing every 250ms)
     */
-    static const uint16_t SenderActiveSensingPeriodicity = 250;
+    static const uint16_t SenderActiveSensingPeriodicity = 300;
+
+    /*! Once an Active Sensing message is received, the unit will begin monitoring 
+    the intervalbetween all subsequent messages. If there is an interval of ActiveSensingPeriodicity ms 
+    or longer betweenmessages while monitoring is active, the same processing 
+    as when All Sound Off, All Notes Off,and Reset All Controllers messages are 
+    received will be carried out. The unit will then stopmonitoring the message interval.
+    */
+    static const bool UseReceiverActiveSensing = false;
+
+    static const uint16_t ReceiverActiveSensingTimeout = 300;
+
 };
 
 END_MIDI_NAMESPACE

--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -72,8 +72,6 @@ struct DefaultSettings
     */
     static const unsigned SysExMaxSize = 128;
 
-    /*! Global switch to turn on/off sender ActiveSensing
-    Set to true to send ActiveSensing
     /*! Global switch to turn on/off sending and receiving ActiveSensing
     Set to true to activate ActiveSensing
     Set to false will not send/receive ActiveSensing message (will also save 236 bytes of memory)

--- a/src/serialMIDI.h
+++ b/src/serialMIDI.h
@@ -116,10 +116,11 @@ END_MIDI_NAMESPACE
 #endif
 
 /*! \brief Create an instance of the library attached to a serial port with
- custom settings.
+ custom MIDI settings (not to be confused with modified Serial Settings, like BaudRate) 
  @see DefaultSettings
  @see MIDI_CREATE_INSTANCE
  */
 #define MIDI_CREATE_CUSTOM_INSTANCE(Type, SerialPort, Name, Settings)           \
     MIDI_NAMESPACE::SerialMIDI<Type> serial##Name(SerialPort);\
     MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type>, Settings> Name((MIDI_NAMESPACE::SerialMIDI<Type>&)serial##Name);
+


### PR DESCRIPTION
# Active Sensing 

2 types of Active Sensing, receiving and sensing of Active Sensing

## receiving Active Sensing

Once an Active Sensing message is received, the unit will begin monitoring the interval between all subsequent messages. If there is an interval of _Settings::ReceiverActiveSensingTimeout_ ms or longer between messages while monitoring is active, the `ErrorActiveSensingTimeout` flag is set and the Error callback is called.  It is up to the application to stop All Notes. The unit will then stop monitoring the message interval.

Turn on receiving Active Sensing using the overwritten `UseReceiverActiveSensing` in Settings

## Sending Active Sensing

ActiveSensing is send `Settings::ActiveSensingPeriodicity` ms after the last command

Turn on sending Active Sensing using the overwritten `UseSenderActiveSensing` in Settings

## Note:

Both `UseReceiverActiveSensing` and `UseSenderActiveSensing` can't be set to true, it's one or the other.

# Serial Settings Example (Hairless MIDI)

Add Hairless example (but currently unrest as hairless is not supported on MaxOS Catalina 64bit)