### PR TITLE
Fix sendPitchBend multiplication

### DIFF
--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -339,7 +339,7 @@ template<class Transport, class Settings, class Platform>
 void MidiInterface<Transport, Settings, Platform>::sendPitchBend(double inPitchValue,
                                                         Channel inChannel)
 {
-    const int scale = inPitchValue > 0.0 ? MIDI_PITCHBEND_MAX : MIDI_PITCHBEND_MIN;
+    const int scale = inPitchValue > 0.0 ? MIDI_PITCHBEND_MAX : - MIDI_PITCHBEND_MIN;
     const int value = int(inPitchValue * double(scale));
     sendPitchBend(value, inChannel);
 }


### PR DESCRIPTION
I tried to use this function and noticed that when the inPitchValue was negative, it was multiplied by MIDI_PITCHBEND_MIN which is negative too and it resulted to a positive pitch bend instead of a negative one. 