### PR TITLE
Settings teensy serial format

### DIFF
--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -99,6 +99,10 @@ struct DefaultSettings
     Setting this field to 0 will disable sending MIDI active sensing.
     */
     static const uint16_t SenderActiveSensingPeriodicity = 0;
+
+    #if defined(TEENSYDUINO)
+    static const uint8_t SerialFormat = SERIAL_8N1;
+    #endif
 };
 
 END_MIDI_NAMESPACE

--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -114,7 +114,7 @@ struct DefaultSettings
 
     Default is SERIAL_8N1
     */
-    static const uint8_t SerialFormat = SERIAL_8N1;
+    static const uint16_t SerialFormat = SERIAL_8N1;
     #endif
 };
 

--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -99,23 +99,6 @@ struct DefaultSettings
     Setting this field to 0 will disable sending MIDI active sensing.
     */
     static const uint16_t SenderActiveSensingPeriodicity = 0;
-
-    #if defined(TEENSYDUINO)
-    /*! Teensy supports various Serial data formats. 
-    This allows to use circuits that may require inversion of polarity on the RX, TX
-    or both signals
-
-    Format Name             Data Bits   Parity  Stop Bits   RX Polarity TX Polarity
-
-    SERIAL_8N1              8           None                Normal      Normal
-    SERIAL_8N1_RXINV        8           None                Inverted    Normal
-    SERIAL_8N1_TXINV        8           None                Normal      Inverted
-    SERIAL_8N1_RXINV_TXINV  8           None                Inverted    Inverted
-
-    Default is SERIAL_8N1
-    */
-    static const uint16_t SerialFormat = SERIAL_8N1;
-    #endif
 };
 
 END_MIDI_NAMESPACE

--- a/src/midi_Settings.h
+++ b/src/midi_Settings.h
@@ -101,6 +101,19 @@ struct DefaultSettings
     static const uint16_t SenderActiveSensingPeriodicity = 0;
 
     #if defined(TEENSYDUINO)
+    /*! Teensy supports various Serial data formats. 
+    This allows to use circuits that may require inversion of polarity on the RX, TX
+    or both signals
+
+    Format Name             Data Bits   Parity  Stop Bits   RX Polarity TX Polarity
+
+    SERIAL_8N1              8           None                Normal      Normal
+    SERIAL_8N1_RXINV        8           None                Inverted    Normal
+    SERIAL_8N1_TXINV        8           None                Normal      Inverted
+    SERIAL_8N1_RXINV_TXINV  8           None                Inverted    Inverted
+
+    Default is SERIAL_8N1
+    */
     static const uint8_t SerialFormat = SERIAL_8N1;
     #endif
 };

--- a/src/serialMIDI.h
+++ b/src/serialMIDI.h
@@ -58,6 +58,8 @@ public:
         // Initialise the Serial port
         #if defined(AVR_CAKE)
             mSerial. template open<Settings::BaudRate>();
+        #elif defined(TEENSYDUINO)
+            mSerial.begin(Settings::BaudRate, SERIAL_8N1_TXINV);
         #else
             mSerial.begin(Settings::BaudRate);
         #endif

--- a/src/serialMIDI.h
+++ b/src/serialMIDI.h
@@ -59,7 +59,7 @@ public:
         #if defined(AVR_CAKE)
             mSerial. template open<Settings::BaudRate>();
         #elif defined(TEENSYDUINO)
-            mSerial.begin(Settings::BaudRate, SERIAL_8N1_TXINV);
+            mSerial.begin(Settings::BaudRate, Settings::SerialFormat);
         #else
             mSerial.begin(Settings::BaudRate);
         #endif

--- a/src/serialMIDI.h
+++ b/src/serialMIDI.h
@@ -30,13 +30,29 @@
 
 BEGIN_MIDI_NAMESPACE
 
-struct DefaultSerialSettings
+struct DefaultSerialSettings : public MIDI_NAMESPACE::DefaultSettings
 {
     /*! Override the default MIDI baudrate to transmit over USB serial, to
     a decoding program such as Hairless MIDI (set baudrate to 115200)\n
     http://projectgus.github.io/hairless-midiserial/
     */
     static const long BaudRate = 31250;
+    #if defined(TEENSYDUINO)
+    /*! Teensy supports various Serial data formats. 
+    Override the default Serial Format to use circuits that may require inversion of 
+    polarity on the RX, TX or both signals.
+    https://www.pjrc.com/teensy/td_serial.html
+
+    Format Name             Data Bits   Parity  RX Polarity  TX Polarity
+
+    SERIAL_8N1              8           None    Normal       Normal
+    SERIAL_8N1_RXINV        8           None    Inverted     Normal
+    SERIAL_8N1_TXINV        8           None    Normal       Inverted
+    SERIAL_8N1_RXINV_TXINV  8           None    Inverted     Inverted
+
+    */
+    static const uint16_t SerialFormat = SERIAL_8N1;
+    #endif
 };
 
 template <class SerialPort, class _Settings = DefaultSerialSettings>
@@ -123,5 +139,5 @@ END_MIDI_NAMESPACE
  @see MIDI_CREATE_INSTANCE
  */
 #define MIDI_CREATE_CUSTOM_INSTANCE(Type, SerialPort, Name, Settings)           \
-    MIDI_NAMESPACE::SerialMIDI<Type> serial##Name(SerialPort);\
-    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type>, Settings> Name((MIDI_NAMESPACE::SerialMIDI<Type>&)serial##Name);
+    MIDI_NAMESPACE::SerialMIDI<Type, Settings> serial##Name(SerialPort);\
+    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type, Settings>, Settings> Name((MIDI_NAMESPACE::SerialMIDI<Type, Settings>&)serial##Name);


### PR DESCRIPTION
It is possible to specify inverted pins on UART ports when using Teensy. This is documented here: https://www.pjrc.com/teensy/td_uart.html under the `Serial1.begin(baud, format)` section.

For MIDI, the relevant formats are :

|Format Name|Data Bits|Parity|RX Polarity|TX Polarity|
|-|-|-|-|-|
|`SERIAL_8N1`|8|None|Normal|Normal|
|`SERIAL_8N1_RXINV`|8|None|Inverted|Normal|
|`SERIAL_8N1_TXINV`|8|None|Normal|Inverted|
|`SERIAL_8N1_RXINV_TXINV`|8|None|Inverted|Inverted|

This allows more flexibility with input and output circuits that may be inverting.

In order to configure the polarity, it is important to inherit the custom settings struct from `DefaultSerialSettings` instead of `DefaultSettings`


```c
struct TXInvMidiSettings : public midi::DefaultSerialSettings
{
    static const uint16_t SerialFormat = SERIAL_8N1_TXINV; // Invert TX
};

MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, Serial1, midi1, TXInvMidiSettings);
```