### PR TITLE
end method for Serial Transport

### DIFF
--- a/src/serialMIDI.h
+++ b/src/serialMIDI.h
@@ -63,6 +63,11 @@ public:
         #endif
 	}
 
+    void end()
+    {
+        mSerial.end();
+    }
+
 	bool beginTransmission(MidiType)
 	{
 		return true;


### PR DESCRIPTION
The Transport layer is started, but could never be stopped.
This change will allow the underlying library to call the end() method in the Transport layers (all other Transport layer have the end() method implemented)

Next step is to call the Transport end() method, when ending the MIDI instance