### PR TITLE
New thru mode: "UnmutedChannels"

### DIFF
--- a/src/MIDI.h
+++ b/src/MIDI.h
@@ -242,6 +242,7 @@ public:
     inline void turnThruOn(Thru::Mode inThruFilterMode = Thru::Full);
     inline void turnThruOff();
     inline void setThruFilterMode(Thru::Mode inThruFilterMode);
+    inline void setThruMutedChannels(bool (&inThruMutedChannels)[17]);
 
 private:
     void thruFilter(byte inChannel);
@@ -279,6 +280,7 @@ private:
     unsigned        mCurrentNrpnNumber;
     bool            mThruActivated  : 1;
     Thru::Mode      mThruFilterMode : 7;
+    bool            mThruMutedChannels[17];
     MidiMessage     mMessage;
     unsigned long   mLastMessageSentTime;
     unsigned long   mLastMessageReceivedTime;

--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -1356,6 +1356,12 @@ inline void MidiInterface<Transport, Settings, Platform>::setThruFilterMode(Thru
 }
 
 template<class Transport, class Settings, class Platform>
+inline void MidiInterface<Transport, Settings, Platform>::setThruMutedChannels(bool (&inThruMutedChannels)[17])
+{
+    memcpy(mThruMutedChannels, inThruMutedChannels, sizeof(inThruMutedChannels));
+}
+
+template<class Transport, class Settings, class Platform>
 inline Thru::Mode MidiInterface<Transport, Settings, Platform>::getFilterMode() const
 {
     return mThruFilterMode;
@@ -1431,6 +1437,17 @@ void MidiInterface<Transport, Settings, Platform>::thruFilter(Channel inChannel)
 
             case Thru::DifferentChannel:
                 if (!filter_condition)
+                {
+                    send(mMessage.type,
+                         mMessage.data1,
+                         mMessage.data2,
+                         mMessage.channel);
+                }
+                break;
+
+            case Thru::UnmutedChannels:
+                if ((mMessage.type == NoteOff) ||
+                    (!mThruMutedChannels[0] && !mThruMutedChannels[mMessage.channel]))
                 {
                     send(mMessage.type,
                          mMessage.data1,

--- a/src/midi_Defs.h
+++ b/src/midi_Defs.h
@@ -132,6 +132,7 @@ struct Thru
         Full                  = 1,  ///< Fully enabled Thru (every incoming message is sent back).
         SameChannel           = 2,  ///< Only the messages on the Input Channel will be sent back.
         DifferentChannel      = 3,  ///< All the messages but the ones on the Input Channel will be sent back.
+        UnmutedChannels       = 4,  ///< Only the messages on channels that are not muted will be sent back.
     };
 };
 


### PR DESCRIPTION
# `Thru::UnmutedChannels`

## What is this?

A new Thru Mode `UnmutedChannels`, where only the messages on channels that are not muted will be sent back.

You may indicate (un)muted channels with an array of `bool` via `setThruMutedChannels()`, where `true` at index `0` means "all channels are muted".

`NoteOff` messages are always sent, even on muted channels in this mode, because otherwise any presently-ringing `NoteOn` events will ring out forever while the channel is muted.

## Why does this exist?

This new Thru Mode allows for an Arduino-powered MIDI Thru box with dedicated hardware toggles for each channel, which may be placed directly after any sequencer to provide control over global track mute state regardless of the sequencer's own track mute functionality.

## Why would that be desirable?

The [Alesis MMT-8](https://www.youtube.com/watch?v=MRLdoZzcd-I) sequencer allowed for a very fluid performance workflow, where global track mute state was independent of the patterns and was not saved or recalled when switching patterns.  Every modern sequencer I've encountered violates the MMT-8 behavior, and insists on being clever about saving and recalling track mute state whenever switching patterns.

This new Thru Mode provides a somewhat elaborate way to replicate the MMT-8 behavior independent of any particular sequencer.

Note: The [Sequentix Cirklon](https://www.sequentix.com/shop/cirklon-hardware-sequencer) provides a "mute hold" feature which would do the same thing, but the Cirklon is unobtainium.

## But, does this really belong here?

Given the niche use case, the potentially surprising `NoteOff` behavior, and the reasonably easy-to-imagine desire to allow all messages other than `NoteOn` pass through a muted channel in this mode, this kind of thing may be better implemented via a custom thru filter function as discussed in issue #40 [here](https://github.com/FortySevenEffects/arduino_midi_library/issues/40#issuecomment-647012093).