### PR TITLE
CUSTOM serial and MIDI creation MACRO's

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -24,6 +24,8 @@ jobs:
           - RPN_NRPN
           - SimpleSynth
           - CustomBaudRate
+          - CustomMIDIsettings
+          - CustomMIDIandSerial
         board:
           - uno
           - due

--- a/examples/CustomBaudRate/CustomBaudRate.ino
+++ b/examples/CustomBaudRate/CustomBaudRate.ino
@@ -8,11 +8,9 @@ struct CustomBaudRateSettings : public MIDI_NAMESPACE::DefaultSerialSettings {
 
 #if defined(ARDUINO_SAM_DUE) || defined(USBCON) || defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__)
     // Leonardo, Due and other USB boards use Serial1 by default.
-    MIDI_NAMESPACE::SerialMIDI<HardwareSerial, CustomBaudRateSettings> serialMIDI(Serial1);
-    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<HardwareSerial, CustomBaudRateSettings>> MIDI((MIDI_NAMESPACE::SerialMIDI<HardwareSerial, CustomBaudRateSettings>&)serialMIDI);
+    MIDI_CREATE_CUSTOMSERIAL_INSTANCE(HardwareSerial, Serial1,  MIDI, CustomBaudRateSettings)
 #else
-    MIDI_NAMESPACE::SerialMIDI<HardwareSerial, CustomBaudRateSettings> serialMIDI(Serial);
-    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<HardwareSerial, CustomBaudRateSettings>> MIDI((MIDI_NAMESPACE::SerialMIDI<HardwareSerial, CustomBaudRateSettings>&)serialMIDI);
+    MIDI_CREATE_CUSTOMSERIAL_INSTANCE(HardwareSerial, Serial,  MIDI, CustomBaudRateSettings)
 #endif
 
 void setup() {

--- a/examples/CustomMIDIandSerial/CustomMIDIandSerial.ino
+++ b/examples/CustomMIDIandSerial/CustomMIDIandSerial.ino
@@ -1,16 +1,22 @@
 #include <MIDI.h>
 
+// Disable the default Use1ByteParsing
+struct CustomMIDISettings : public MIDI_NAMESPACE::DefaultSettings {
+  static const bool Use1ByteParsing = false;
+};
+
 // Override the default MIDI baudrate to
 // a decoding program such as Hairless MIDI (set baudrate to 115200)
 struct CustomSerialSettings : public MIDI_NAMESPACE::DefaultSerialSettings {
   static const long BaudRate = 115200;
 };
 
+
 #if defined(ARDUINO_SAM_DUE) || defined(USBCON) || defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__)
     // Leonardo, Due and other USB boards use Serial1 by default.
-    MIDI_CREATE_CUSTOMSERIAL_INSTANCE(HardwareSerial, Serial1,  MIDI, CustomSerialSettings)
+    MIDI_CREATE_SPECIAL_INSTANCE(HardwareSerial, Serial1,  MIDI, CustomMIDISettings, CustomSerialSettings)
 #else
-    MIDI_CREATE_CUSTOMSERIAL_INSTANCE(HardwareSerial, Serial,  MIDI, CustomSerialSettings)
+    MIDI_CREATE_SPECIAL_INSTANCE(HardwareSerial, Serial,  MIDI, CustomMIDISettings, CustomSerialSettings)
 #endif
 
 void setup() {

--- a/examples/CustomMIDIsettings/CustomMIDIsettings.ino
+++ b/examples/CustomMIDIsettings/CustomMIDIsettings.ino
@@ -1,16 +1,15 @@
 #include <MIDI.h>
 
-// Override the default MIDI baudrate to
-// a decoding program such as Hairless MIDI (set baudrate to 115200)
-struct CustomSerialSettings : public MIDI_NAMESPACE::DefaultSerialSettings {
-  static const long BaudRate = 115200;
+// Disable the default Use1ByteParsing
+struct CustomMIDISettings : public MIDI_NAMESPACE::DefaultSettings {
+  static const bool Use1ByteParsing = false;
 };
 
 #if defined(ARDUINO_SAM_DUE) || defined(USBCON) || defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__)
     // Leonardo, Due and other USB boards use Serial1 by default.
-    MIDI_CREATE_CUSTOMSERIAL_INSTANCE(HardwareSerial, Serial1,  MIDI, CustomSerialSettings)
+    MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, Serial1,  MIDI, CustomMIDISettings)
 #else
-    MIDI_CREATE_CUSTOMSERIAL_INSTANCE(HardwareSerial, Serial,  MIDI, CustomSerialSettings)
+    MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, Serial,  MIDI, CustomMIDISettings)
 #endif
 
 void setup() {

--- a/keywords.txt
+++ b/keywords.txt
@@ -10,6 +10,7 @@ MIDI	KEYWORD1
 MIDI.h	KEYWORD1
 MidiInterface	KEYWORD1
 DefaultSettings	KEYWORD1
+DefaultSerialSettings	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/src/serialMIDI.h
+++ b/src/serialMIDI.h
@@ -98,6 +98,20 @@ private:
 
 END_MIDI_NAMESPACE
 
+/*! \brief Create an instance of the library attached to a serial port 
+ with overwritten MIDI & Serial Settings
+ */
+#define MIDI_CREATE_SPECIAL_INSTANCE(Type, SerialPort, Name, CustomMIDISettings, CustomSerialSettings)  \
+    MIDI_NAMESPACE::SerialMIDI<Type, CustomSerialSettings> serial##Name(SerialPort); \
+    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type, CustomSerialSettings>, CustomMIDISettings> Name((MIDI_NAMESPACE::SerialMIDI<Type, CustomSerialSettings>&)serial##Name);
+
+/*! \brief Create an instance of the library attached to a serial port 
+ with overwritten Serial Settings
+ */
+#define MIDI_CREATE_CUSTOMSERIAL_INSTANCE(Type, SerialPort, Name, CustomSerialSettings)  \
+    MIDI_NAMESPACE::SerialMIDI<Type, CustomSerialSettings> serial##Name(SerialPort); \
+    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type, CustomSerialSettings>> Name((MIDI_NAMESPACE::SerialMIDI<Type, CustomSerialSettings>&)serial##Name);
+
 /*! \brief Create an instance of the library attached to a serial port.
  You can use HardwareSerial or SoftwareSerial for the serial port.
  Example: MIDI_CREATE_INSTANCE(HardwareSerial, Serial2, midi2);
@@ -125,6 +139,6 @@ END_MIDI_NAMESPACE
  @see DefaultSettings
  @see MIDI_CREATE_INSTANCE
  */
-#define MIDI_CREATE_CUSTOM_INSTANCE(Type, SerialPort, Name, Settings)           \
+#define MIDI_CREATE_CUSTOM_INSTANCE(Type, SerialPort, Name, CustomMIDISettings)           \
     MIDI_NAMESPACE::SerialMIDI<Type> serial##Name(SerialPort);\
-    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type>, Settings> Name((MIDI_NAMESPACE::SerialMIDI<Type>&)serial##Name);
+    MIDI_NAMESPACE::MidiInterface<MIDI_NAMESPACE::SerialMIDI<Type>, CustomMIDISettings> Name((MIDI_NAMESPACE::SerialMIDI<Type>&)serial##Name);


### PR DESCRIPTION
- MIDI_CREATE_CUSTOMSERIAL_INSTANCE: both overwritten serial and MIDI settings
- MIDI_CREATE_SPECIAL_INSTANCE: overwritten serial settings
(overwritten MIDI settings MACRO already exists)