### PR TITLE
Replace all hardcoded "midi::" namespace by "MIDI_NAMESPACE::"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Migration has been made as easy as possible: only the declaration of the MIDI ob
 #include <midi_UsbTransport.h>
 
 static const unsigned sUsbTransportBufferSize = 16;
-typedef midi::UsbTransport<sUsbTransportBufferSize> UsbTransport;
+typedef MIDI_NAMESPACE::UsbTransport<sUsbTransportBufferSize> UsbTransport;
 
 UsbTransport sUsbTransport;
 

--- a/doc/sysex-codec.md
+++ b/doc/sysex-codec.md
@@ -42,11 +42,11 @@ static const byte myData[12] = {
 };
 
 byte encoded[16];
-const unsigned encodedSize = midi::encodeSysEx(myData, encoded, 12);
+const unsigned encodedSize = MIDI_NAMESPACE::encodeSysEx(myData, encoded, 12);
 // Encoded hex dump: 07 4a 7e 3a 3e 3a 2d 70 07 0d 7a 4a 5e 42
 
 byte decoded[12];
-const unsigned decoded = midi::decodeSysEx(encoded, decoded, encodedSize);
+const unsigned decoded = MIDI_NAMESPACE::decodeSysEx(encoded, decoded, encodedSize);
 ```
 
 ## Special case for Korg devices

--- a/examples/Input/Input.ino
+++ b/examples/Input/Input.ino
@@ -36,7 +36,7 @@ void loop()
     {
         switch(MIDI.getType())      // Get the type of the message we caught
         {
-            case midi::ProgramChange:       // If it is a Program Change,
+            case MIDI_NAMESPACE::ProgramChange:       // If it is a Program Change,
                 BlinkLed(MIDI.getData1());  // blink the LED a number of times
                                             // correponding to the program number
                                             // (0 to 127, it can last a while..)

--- a/examples/RPN_NRPN/RPN_NRPN.ino
+++ b/examples/RPN_NRPN/RPN_NRPN.ino
@@ -51,7 +51,7 @@ public:
                 }
                 break;
 
-            case midi::DataIncrement:
+            case MIDI_NAMESPACE::DataIncrement:
                 if (mSelected)
                 {
                     Value& currentValue = getCurrentValue();
@@ -59,7 +59,7 @@ public:
                     return true;
                 }
                 break;
-            case midi::DataDecrement:
+            case MIDI_NAMESPACE::DataDecrement:
                 if (mSelected)
                 {
                     Value& currentValue = getCurrentValue();
@@ -68,7 +68,7 @@ public:
                 }
                 break;
 
-            case midi::DataEntryMSB:
+            case MIDI_NAMESPACE::DataEntryMSB:
                 if (mSelected)
                 {
                     Value& currentValue = getCurrentValue();
@@ -77,7 +77,7 @@ public:
                     return true;
                 }
                 break;
-            case midi::DataEntryLSB:
+            case MIDI_NAMESPACE::DataEntryLSB:
                 if (mSelected)
                 {
                     Value& currentValue = getCurrentValue();
@@ -113,8 +113,8 @@ public:
 
 typedef State<2> RpnState;  // We'll listen to 2 RPN
 typedef State<4> NrpnState; // and 4 NRPN
-typedef ParameterNumberParser<RpnState,  midi::RPNMSB,  midi::RPNLSB>  RpnParser;
-typedef ParameterNumberParser<NrpnState, midi::NRPNMSB, midi::NRPNLSB> NrpnParser;
+typedef ParameterNumberParser<RpnState,  MIDI_NAMESPACE::RPNMSB,  MIDI_NAMESPACE::RPNLSB>  RpnParser;
+typedef ParameterNumberParser<NrpnState, MIDI_NAMESPACE::NRPNMSB, MIDI_NAMESPACE::NRPNLSB> NrpnParser;
 
 struct ChannelSetup
 {
@@ -131,8 +131,8 @@ struct ChannelSetup
     }
     inline void setup()
     {
-        mRpnState.enable(midi::RPN::PitchBendSensitivity);
-        mRpnState.enable(midi::RPN::ModulationDepthRange);
+        mRpnState.enable(MIDI_NAMESPACE::RPN::PitchBendSensitivity);
+        mRpnState.enable(MIDI_NAMESPACE::RPN::ModulationDepthRange);
 
         // Enable a few random NRPNs
         mNrpnState.enable(12);
@@ -160,13 +160,13 @@ void handleControlChange(byte inChannel, byte inNumber, byte inValue)
         const Value& value    = channel.mRpnParser.getCurrentValue();
         const unsigned number = channel.mRpnParser.mCurrentNumber.as14bits();
 
-        if (number == midi::RPN::PitchBendSensitivity)
+        if (number == MIDI_NAMESPACE::RPN::PitchBendSensitivity)
         {
             // Here, we use the LSB and MSB separately as they have different meaning.
             const byte semitones    = value.mMsb;
             const byte cents        = value.mLsb;
         }
-        else if (number == midi::RPN::ModulationDepthRange)
+        else if (number == MIDI_NAMESPACE::RPN::ModulationDepthRange)
         {
             // But here, we want the full 14 bit value.
             const unsigned range = value.as14bits();
@@ -198,10 +198,10 @@ void loop()
 
     // Send a RPN sequence (Pitch Bend sensitivity) on channel 1
     {
-        const midi::Channel channel = 1;
+        const MIDI_NAMESPACE::Channel channel = 1;
         const byte semitones = 12;
         const byte cents     = 42;
-        MIDI.beginRpn(midi::RPN::PitchBendSensitivity, channel);
+        MIDI.beginRpn(MIDI_NAMESPACE::RPN::PitchBendSensitivity, channel);
         MIDI.sendRpnValue(semitones, cents, channel);
         MIDI.endRpn(channel);
     }

--- a/src/midi_Message.h
+++ b/src/midi_Message.h
@@ -62,7 +62,7 @@ struct Message
         , valid(inOther.valid)
         , length(inOther.length)
     {
-        if (type == midi::SystemExclusive)
+        if (type == MIDI_NAMESPACE::SystemExclusive)
         {
             memcpy(sysexArray, inOther.sysexArray, sSysExMaxSize * sizeof(DataByte));
         }

--- a/test/unit-tests/tests/unit-tests_MidiInput.cpp
+++ b/test/unit-tests/tests/unit-tests_MidiInput.cpp
@@ -14,11 +14,11 @@ BEGIN_UNNAMED_NAMESPACE
 using namespace testing;
 USING_NAMESPACE_UNIT_TESTS
 typedef test_mocks::SerialMock<32> SerialMock;
-typedef midi::SerialMIDI<SerialMock> Transport;
-typedef midi::MidiInterface<Transport> MidiInterface;
+typedef MIDI_NAMESPACE::SerialMIDI<SerialMock> Transport;
+typedef MIDI_NAMESPACE::MidiInterface<Transport> MidiInterface;
 
 template<unsigned Size>
-struct VariableSysExSettings : midi::DefaultSettings
+struct VariableSysExSettings : MIDI_NAMESPACE::DefaultSettings
 {
     static const unsigned SysExMaxSize = Size;
 };
@@ -26,35 +26,35 @@ struct VariableSysExSettings : midi::DefaultSettings
 TEST(MidiInput, getTypeFromStatusByte)
 {
     // Channel Messages
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0x81), midi::NoteOff);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0x92), midi::NoteOn);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xa3), midi::AfterTouchPoly);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xb4), midi::ControlChange);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xc5), midi::ProgramChange);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xd6), midi::AfterTouchChannel);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xe7), midi::PitchBend);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0x81), MIDI_NAMESPACE::NoteOff);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0x92), MIDI_NAMESPACE::NoteOn);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xa3), MIDI_NAMESPACE::AfterTouchPoly);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xb4), MIDI_NAMESPACE::ControlChange);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xc5), MIDI_NAMESPACE::ProgramChange);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xd6), MIDI_NAMESPACE::AfterTouchChannel);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xe7), MIDI_NAMESPACE::PitchBend);
 
     // System Messages
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf0), midi::SystemExclusive);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf1), midi::TimeCodeQuarterFrame);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf2), midi::SongPosition);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf3), midi::SongSelect);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf6), midi::TuneRequest);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf8), midi::Clock);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfa), midi::Start);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfb), midi::Continue);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfc), midi::Stop);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfe), midi::ActiveSensing);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xff), midi::SystemReset);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf0), MIDI_NAMESPACE::SystemExclusive);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf1), MIDI_NAMESPACE::TimeCodeQuarterFrame);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf2), MIDI_NAMESPACE::SongPosition);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf3), MIDI_NAMESPACE::SongSelect);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf6), MIDI_NAMESPACE::TuneRequest);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf8), MIDI_NAMESPACE::Clock);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfa), MIDI_NAMESPACE::Start);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfb), MIDI_NAMESPACE::Continue);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfc), MIDI_NAMESPACE::Stop);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfe), MIDI_NAMESPACE::ActiveSensing);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xff), MIDI_NAMESPACE::SystemReset);
 
     // Invalid Messages
     for (int i = 0; i < 0x80; ++i)
     {
-        EXPECT_EQ(MidiInterface::getTypeFromStatusByte(i), midi::InvalidType);
+        EXPECT_EQ(MidiInterface::getTypeFromStatusByte(i), MIDI_NAMESPACE::InvalidType);
     }
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf4), midi::InvalidType);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf5), midi::InvalidType);
-    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfd), midi::InvalidType);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf4), MIDI_NAMESPACE::InvalidType);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xf5), MIDI_NAMESPACE::InvalidType);
+    EXPECT_EQ(MidiInterface::getTypeFromStatusByte(0xfd), MIDI_NAMESPACE::InvalidType);
 }
 
 TEST(MidiInput, getChannelFromStatusByte)
@@ -67,25 +67,25 @@ TEST(MidiInput, getChannelFromStatusByte)
 
 TEST(MidiInput, isChannelMessage)
 {
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::InvalidType),           false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::NoteOff),               true);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::NoteOn),                true);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::AfterTouchPoly),        true);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::ControlChange),         true);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::ProgramChange),         true);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::AfterTouchChannel),     true);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::PitchBend),             true);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::SystemExclusive),       false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::TimeCodeQuarterFrame),  false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::SongPosition),          false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::SongSelect),            false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::TuneRequest),           false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::Clock),                 false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::Start),                 false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::Continue),              false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::Stop),                  false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::ActiveSensing),         false);
-    EXPECT_EQ(MidiInterface::isChannelMessage(midi::SystemReset),           false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::InvalidType),           false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::NoteOff),               true);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::NoteOn),                true);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::AfterTouchPoly),        true);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::ControlChange),         true);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::ProgramChange),         true);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::AfterTouchChannel),     true);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::PitchBend),             true);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::SystemExclusive),       false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::TimeCodeQuarterFrame),  false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::SongPosition),          false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::SongSelect),            false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::TuneRequest),           false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::Clock),                 false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::Start),                 false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::Continue),              false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::Stop),                  false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::ActiveSensing),         false);
+    EXPECT_EQ(MidiInterface::isChannelMessage(MIDI_NAMESPACE::SystemReset),           false);
 }
 
 // --
@@ -124,7 +124,7 @@ TEST(MidiInput, initMessage)
     Transport transport(serial);
     MidiInterface midi((Transport&)transport);
 
-    EXPECT_EQ(midi.getType(),               midi::InvalidType);
+    EXPECT_EQ(midi.getType(),               MIDI_NAMESPACE::InvalidType);
     EXPECT_EQ(midi.getChannel(),            0);
     EXPECT_EQ(midi.getData1(),              0);
     EXPECT_EQ(midi.getData2(),              0);
@@ -175,7 +175,7 @@ TEST(MidiInput, inputDisabled)
 TEST(MidiInput, multiByteParsing)
 {
     typedef VariableSettings<false, false> Settings;
-    typedef midi::MidiInterface<Transport, Settings> MultiByteMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> MultiByteMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -210,7 +210,7 @@ TEST(MidiInput, noteOn)
     EXPECT_EQ(midi.read(), true);
 
     // First NoteOn
-    EXPECT_EQ(midi.getType(),       midi::NoteOn);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOn);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -219,7 +219,7 @@ TEST(MidiInput, noteOn)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::NoteOn);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOn);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      78);
@@ -227,7 +227,7 @@ TEST(MidiInput, noteOn)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::NoteOn);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOn);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -235,7 +235,7 @@ TEST(MidiInput, noteOn)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::NoteOff);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOff);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      0);
@@ -262,7 +262,7 @@ TEST(MidiInput, noteOff)
     EXPECT_EQ(midi.read(), true);
 
     // First NoteOn
-    EXPECT_EQ(midi.getType(),       midi::NoteOff);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOff);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -271,7 +271,7 @@ TEST(MidiInput, noteOff)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::NoteOff);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOff);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      78);
@@ -279,7 +279,7 @@ TEST(MidiInput, noteOff)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::NoteOff);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOff);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -303,14 +303,14 @@ TEST(MidiInput, programChange)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::ProgramChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ProgramChange);
     EXPECT_EQ(midi.getChannel(),    4);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::ProgramChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ProgramChange);
     EXPECT_EQ(midi.getChannel(),    4);
     EXPECT_EQ(midi.getData1(),      34);
     EXPECT_EQ(midi.getData2(),      0);
@@ -318,14 +318,14 @@ TEST(MidiInput, programChange)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::ProgramChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ProgramChange);
     EXPECT_EQ(midi.getChannel(),    5);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::ProgramChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ProgramChange);
     EXPECT_EQ(midi.getChannel(),    5);
     EXPECT_EQ(midi.getData1(),      78);
     EXPECT_EQ(midi.getData2(),      0);
@@ -352,7 +352,7 @@ TEST(MidiInput, controlChange)
     EXPECT_EQ(midi.read(), true);
 
     // First NoteOn
-    EXPECT_EQ(midi.getType(),       midi::ControlChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -361,7 +361,7 @@ TEST(MidiInput, controlChange)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::ControlChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      78);
@@ -369,7 +369,7 @@ TEST(MidiInput, controlChange)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::ControlChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -396,7 +396,7 @@ TEST(MidiInput, pitchBend)
     EXPECT_EQ(midi.read(), true);
 
     // First NoteOn
-    EXPECT_EQ(midi.getType(),       midi::PitchBend);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::PitchBend);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -405,7 +405,7 @@ TEST(MidiInput, pitchBend)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::PitchBend);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::PitchBend);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      78);
@@ -413,7 +413,7 @@ TEST(MidiInput, pitchBend)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::PitchBend);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::PitchBend);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -440,7 +440,7 @@ TEST(MidiInput, afterTouchPoly)
     EXPECT_EQ(midi.read(), true);
 
     // First NoteOn
-    EXPECT_EQ(midi.getType(),       midi::AfterTouchPoly);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::AfterTouchPoly);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -449,7 +449,7 @@ TEST(MidiInput, afterTouchPoly)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::AfterTouchPoly);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::AfterTouchPoly);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      78);
@@ -457,7 +457,7 @@ TEST(MidiInput, afterTouchPoly)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::AfterTouchPoly);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::AfterTouchPoly);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -481,14 +481,14 @@ TEST(MidiInput, afterTouchChannel)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::AfterTouchChannel);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::AfterTouchChannel);
     EXPECT_EQ(midi.getChannel(),    4);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::AfterTouchChannel);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::AfterTouchChannel);
     EXPECT_EQ(midi.getChannel(),    4);
     EXPECT_EQ(midi.getData1(),      34);
     EXPECT_EQ(midi.getData2(),      0);
@@ -496,14 +496,14 @@ TEST(MidiInput, afterTouchChannel)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::AfterTouchChannel);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::AfterTouchChannel);
     EXPECT_EQ(midi.getChannel(),    5);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::AfterTouchChannel);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::AfterTouchChannel);
     EXPECT_EQ(midi.getChannel(),    5);
     EXPECT_EQ(midi.getData1(),      78);
     EXPECT_EQ(midi.getData2(),      0);
@@ -513,8 +513,8 @@ TEST(MidiInput, sysExWithinBufferSize)
 {
     typedef VariableSysExSettings<1024> Settings;
     typedef test_mocks::SerialMock<2048> LargerSerialMock;
-    typedef midi::SerialMIDI<LargerSerialMock> LargerTransport;
-    typedef midi::MidiInterface<LargerTransport, Settings> LargerMidiInterface;
+    typedef MIDI_NAMESPACE::SerialMIDI<LargerSerialMock> LargerTransport;
+    typedef MIDI_NAMESPACE::MidiInterface<LargerTransport, Settings> LargerMidiInterface;
 
     LargerSerialMock serial;
     LargerTransport transport(serial);
@@ -581,7 +581,7 @@ TEST(MidiInput, sysExWithinBufferSize)
 TEST(MidiInput, sysExOverBufferSize)
 {
     typedef VariableSysExSettings<8> Settings;
-    typedef midi::MidiInterface<Transport, Settings> SmallMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> SmallMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -630,7 +630,7 @@ TEST(MidiInput, mtcQuarterFrame)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::TimeCodeQuarterFrame);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::TimeCodeQuarterFrame);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      0);
@@ -638,7 +638,7 @@ TEST(MidiInput, mtcQuarterFrame)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::TimeCodeQuarterFrame);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::TimeCodeQuarterFrame);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      42);
     EXPECT_EQ(midi.getData2(),      0);
@@ -663,7 +663,7 @@ TEST(MidiInput, songPosition)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::SongPosition);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::SongPosition);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
@@ -672,7 +672,7 @@ TEST(MidiInput, songPosition)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::SongPosition);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::SongPosition);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      56);
     EXPECT_EQ(midi.getData2(),      78);
@@ -696,7 +696,7 @@ TEST(MidiInput, songSelect)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::SongSelect);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::SongSelect);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      0);
@@ -704,7 +704,7 @@ TEST(MidiInput, songSelect)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
 
-    EXPECT_EQ(midi.getType(),       midi::SongSelect);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::SongSelect);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      42);
     EXPECT_EQ(midi.getData2(),      0);
@@ -724,7 +724,7 @@ TEST(MidiInput, tuneRequest)
     serial.mRxBuffer.write(rxData, rxSize);
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::TuneRequest);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::TuneRequest);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      0);
     EXPECT_EQ(midi.getData2(),      0);
@@ -744,31 +744,31 @@ TEST(MidiInput, realTime)
     serial.mRxBuffer.write(rxData, rxSize);
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::Clock);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Clock);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      0);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true); 
-    EXPECT_EQ(midi.getType(),       midi::Tick);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Tick);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      0);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::Start);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Start);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      0);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::Continue);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Continue);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      0);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::Stop);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Stop);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      0);
     EXPECT_EQ(midi.getData2(),      0);
@@ -776,13 +776,13 @@ TEST(MidiInput, realTime)
     EXPECT_EQ(midi.read(), false); // 0xfd = undefined
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::ActiveSensing);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ActiveSensing);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      0);
     EXPECT_EQ(midi.getData2(),      0);
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::SystemReset);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::SystemReset);
     EXPECT_EQ(midi.getChannel(),    0);
     EXPECT_EQ(midi.getData1(),      0);
     EXPECT_EQ(midi.getData2(),      0);
@@ -813,52 +813,52 @@ TEST(MidiInput, interleavedRealTime)
         EXPECT_EQ(midi.read(), false);
 
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::Clock);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Clock);
         EXPECT_EQ(midi.getChannel(),    0);
         EXPECT_EQ(midi.getData1(),      0);
         EXPECT_EQ(midi.getData2(),      0);
 
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::NoteOn);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOn);
         EXPECT_EQ(midi.getChannel(),    12);
         EXPECT_EQ(midi.getData1(),      12);
         EXPECT_EQ(midi.getData2(),      34);
 
         EXPECT_EQ(midi.read(), false);
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::NoteOff);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOff);
         EXPECT_EQ(midi.getChannel(),    12);
         EXPECT_EQ(midi.getData1(),      12);
         EXPECT_EQ(midi.getData2(),      0);
 
         EXPECT_EQ(midi.read(), false);
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::Clock);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Clock);
         EXPECT_EQ(midi.getChannel(),    0);
         EXPECT_EQ(midi.getData1(),      0);
         EXPECT_EQ(midi.getData2(),      0);
 
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::NoteOn);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOn);
         EXPECT_EQ(midi.getChannel(),    12);
         EXPECT_EQ(midi.getData1(),      42);
         EXPECT_EQ(midi.getData2(),      127);
 
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::Clock);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Clock);
         EXPECT_EQ(midi.getChannel(),    0);
         EXPECT_EQ(midi.getData1(),      0);
         EXPECT_EQ(midi.getData2(),      0);
 
         EXPECT_EQ(midi.read(), false);
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::Clock);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::Clock);
         EXPECT_EQ(midi.getChannel(),    0);
         EXPECT_EQ(midi.getData1(),      0);
         EXPECT_EQ(midi.getData2(),      0);
 
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::NoteOff);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::NoteOff);
         EXPECT_EQ(midi.getChannel(),    12);
         EXPECT_EQ(midi.getData1(),      42);
         EXPECT_EQ(midi.getData2(),      0);
@@ -877,7 +877,7 @@ TEST(MidiInput, interleavedRealTime)
         EXPECT_EQ(midi.read(), false);
 
         EXPECT_EQ(midi.read(), true);
-        EXPECT_EQ(midi.getType(),       midi::ActiveSensing);
+        EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ActiveSensing);
         EXPECT_EQ(midi.getChannel(),    0);
         EXPECT_EQ(midi.getData1(),      0);
         EXPECT_EQ(midi.getData2(),      0);
@@ -935,14 +935,14 @@ TEST(MidiInput, strayUndefinedOneByteParsing)
     EXPECT_EQ(midi.read(), false); // Invalid, should not reset parser
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::ControlChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);
 
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::ControlChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      0);
@@ -950,7 +950,7 @@ TEST(MidiInput, strayUndefinedOneByteParsing)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::ControlChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      42);
     EXPECT_EQ(midi.getData2(),      127);
@@ -959,7 +959,7 @@ TEST(MidiInput, strayUndefinedOneByteParsing)
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), false);
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::ControlChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      42);
     EXPECT_EQ(midi.getData2(),      0);
@@ -968,7 +968,7 @@ TEST(MidiInput, strayUndefinedOneByteParsing)
 TEST(MidiInput, strayUndefinedMultiByteParsing)
 {
     typedef VariableSettings<false, false> Settings;
-    typedef midi::MidiInterface<Transport, Settings> MultiByteMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> MultiByteMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -982,7 +982,7 @@ TEST(MidiInput, strayUndefinedMultiByteParsing)
     serial.mRxBuffer.write(rxData, rxSize);
 
     EXPECT_EQ(midi.read(), true);
-    EXPECT_EQ(midi.getType(),       midi::ControlChange);
+    EXPECT_EQ(midi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(midi.getChannel(),    12);
     EXPECT_EQ(midi.getData1(),      12);
     EXPECT_EQ(midi.getData2(),      34);

--- a/test/unit-tests/tests/unit-tests_MidiInputCallbacks.cpp
+++ b/test/unit-tests/tests/unit-tests_MidiInputCallbacks.cpp
@@ -15,16 +15,16 @@ using namespace testing;
 USING_NAMESPACE_UNIT_TESTS
 
 template<unsigned Size>
-struct VariableSysExSettings : midi::DefaultSettings
+struct VariableSysExSettings : MIDI_NAMESPACE::DefaultSettings
 {
     static const unsigned SysExMaxSize = Size;
 };
 
 typedef test_mocks::SerialMock<256> SerialMock;
-typedef midi::SerialMIDI<SerialMock> Transport;
+typedef MIDI_NAMESPACE::SerialMIDI<SerialMock> Transport;
 
 typedef VariableSysExSettings<256> Settings;
-typedef midi::MidiInterface<Transport, Settings> MidiInterface;
+typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> MidiInterface;
 
 MidiInterface* midi;
 
@@ -78,7 +78,7 @@ TEST_F(MidiInputCallbacks, noteOn)
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::NoteOn);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::NoteOn);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      34);
@@ -97,7 +97,7 @@ TEST_F(MidiInputCallbacks, noteOn)
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::NoteOff);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::NoteOff);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      0);
@@ -126,7 +126,7 @@ TEST_F(MidiInputCallbacks, noteOff)
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::NoteOff);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::NoteOff);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      34);
@@ -145,7 +145,7 @@ TEST_F(MidiInputCallbacks, noteOff)
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::NoteOff);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::NoteOff);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      0);
@@ -180,7 +180,7 @@ TEST_F(MidiInputCallbacks, afterTouchPoly)
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::AfterTouchPoly);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::AfterTouchPoly);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      34);
@@ -212,7 +212,7 @@ TEST_F(MidiInputCallbacks, controlChange)
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::ControlChange);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::ControlChange);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      34);
@@ -243,7 +243,7 @@ TEST_F(MidiInputCallbacks, programChange)
 
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::ProgramChange);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::ProgramChange);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      0);
@@ -275,7 +275,7 @@ TEST_F(MidiInputCallbacks, afterTouchChannel)
 
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::AfterTouchChannel);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::AfterTouchChannel);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      0);
@@ -307,7 +307,7 @@ TEST_F(MidiInputCallbacks, pitchBend)
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::PitchBend);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::PitchBend);
     EXPECT_EQ(mMidi.getChannel(),    12);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      34);
@@ -343,7 +343,7 @@ TEST_F(MidiInputCallbacks, sysEx)
         EXPECT_EQ(mMidi.read(), false);
     }
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),              midi::SystemExclusive);
+    EXPECT_EQ(mMidi.getType(),              MIDI_NAMESPACE::SystemExclusive);
     EXPECT_EQ(mMidi.getChannel(),           0);
     EXPECT_EQ(mMidi.getSysExArrayLength(),  rxSize);
 
@@ -387,7 +387,7 @@ TEST_F(MidiInputCallbacks, sysExLong)
         EXPECT_EQ(mMidi.read(), false);
     }
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),              midi::SystemExclusive);
+    EXPECT_EQ(mMidi.getType(),              MIDI_NAMESPACE::SystemExclusive);
     EXPECT_EQ(mMidi.getChannel(),           0);
     EXPECT_EQ(mMidi.getSysExArrayLength(),  rxSize);
 
@@ -417,7 +417,7 @@ TEST_F(MidiInputCallbacks, mtcQuarterFrame)
 
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::TimeCodeQuarterFrame);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::TimeCodeQuarterFrame);
     EXPECT_EQ(mMidi.getChannel(),    0);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      0);
@@ -449,7 +449,7 @@ TEST_F(MidiInputCallbacks, songPosition)
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::SongPosition);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::SongPosition);
     EXPECT_EQ(mMidi.getChannel(),    0);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      34);
@@ -480,7 +480,7 @@ TEST_F(MidiInputCallbacks, songSelect)
 
     EXPECT_EQ(mMidi.read(), false);
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::SongSelect);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::SongSelect);
     EXPECT_EQ(mMidi.getChannel(),    0);
     EXPECT_EQ(mMidi.getData1(),      12);
     EXPECT_EQ(mMidi.getData2(),      0);
@@ -508,7 +508,7 @@ TEST_F(MidiInputCallbacks, tuneRequest)
     mSerial.mRxBuffer.write(0xf6);
 
     EXPECT_EQ(mMidi.read(), true);
-    EXPECT_EQ(mMidi.getType(),       midi::TuneRequest);
+    EXPECT_EQ(mMidi.getType(),       MIDI_NAMESPACE::TuneRequest);
     EXPECT_EQ(mMidi.getChannel(),    0);
     EXPECT_EQ(mMidi.getData1(),      0);
     EXPECT_EQ(mMidi.getData2(),      0);
@@ -522,32 +522,32 @@ TEST_F(MidiInputCallbacks, tuneRequest)
 void handleClock()
 {
     EXPECT_NE(midi, nullptr);
-    midi->sendRealTime(midi::Clock);
+    midi->sendRealTime(MIDI_NAMESPACE::Clock);
 }
 void handleStart()
 {
     EXPECT_NE(midi, nullptr);
-    midi->sendRealTime(midi::Start);
+    midi->sendRealTime(MIDI_NAMESPACE::Start);
 }
 void handleContinue()
 {
     EXPECT_NE(midi, nullptr);
-    midi->sendRealTime(midi::Continue);
+    midi->sendRealTime(MIDI_NAMESPACE::Continue);
 }
 void handleStop()
 {
     EXPECT_NE(midi, nullptr);
-    midi->sendRealTime(midi::Stop);
+    midi->sendRealTime(MIDI_NAMESPACE::Stop);
 }
 void handleActiveSensing()
 {
     EXPECT_NE(midi, nullptr);
-    midi->sendRealTime(midi::ActiveSensing);
+    midi->sendRealTime(MIDI_NAMESPACE::ActiveSensing);
 }
 void handleSystemReset()
 {
     EXPECT_NE(midi, nullptr);
-    midi->sendRealTime(midi::SystemReset);
+    midi->sendRealTime(MIDI_NAMESPACE::SystemReset);
 }
 
 TEST_F(MidiInputCallbacks, realTime)
@@ -567,13 +567,13 @@ TEST_F(MidiInputCallbacks, realTime)
         0xf8, 0xfa, 0xfb, 0xfc, 0xfe, 0xff
     };
     mSerial.mRxBuffer.write(rxData, rxSize);
-    static const midi::MidiType types[rxSize] = {
-        midi::Clock,
-        midi::Start,
-        midi::Continue,
-        midi::Stop,
-        midi::ActiveSensing,
-        midi::SystemReset,
+    static const MIDI_NAMESPACE::MidiType types[rxSize] = {
+        MIDI_NAMESPACE::Clock,
+        MIDI_NAMESPACE::Start,
+        MIDI_NAMESPACE::Continue,
+        MIDI_NAMESPACE::Stop,
+        MIDI_NAMESPACE::ActiveSensing,
+        MIDI_NAMESPACE::SystemReset,
     };
 
     for (unsigned i = 0; i < rxSize; ++i)

--- a/test/unit-tests/tests/unit-tests_MidiMessage.cpp
+++ b/test/unit-tests/tests/unit-tests_MidiMessage.cpp
@@ -17,7 +17,7 @@ BEGIN_UNNAMED_NAMESPACE
 
 TEST(MidiMessage, hasTheRightProperties)
 {
-    typedef midi::Message<42> Message;
+    typedef MIDI_NAMESPACE::Message<42> Message;
     const Message message = Message();
     EXPECT_EQ(message.channel,  0);
     EXPECT_EQ(message.type,     0);
@@ -38,7 +38,7 @@ TEST(MidiMessage, getSysExSize)
 {
     // Small message
     {
-        typedef midi::Message<32> Message;
+        typedef MIDI_NAMESPACE::Message<32> Message;
         ASSERT_EQ(Message::sSysExMaxSize, unsigned(32));
         Message message = Message();
 
@@ -52,7 +52,7 @@ TEST(MidiMessage, getSysExSize)
     }
     // Medium message
     {
-        typedef midi::Message<256> Message;
+        typedef MIDI_NAMESPACE::Message<256> Message;
         ASSERT_EQ(Message::sSysExMaxSize, unsigned(256));
         Message message = Message();
 
@@ -66,7 +66,7 @@ TEST(MidiMessage, getSysExSize)
     }
     // Large message
     {
-        typedef midi::Message<1024> Message;
+        typedef MIDI_NAMESPACE::Message<1024> Message;
         ASSERT_EQ(Message::sSysExMaxSize, unsigned(1024));
         Message message = Message();
 

--- a/test/unit-tests/tests/unit-tests_MidiOutput.cpp
+++ b/test/unit-tests/tests/unit-tests_MidiOutput.cpp
@@ -15,8 +15,8 @@ using namespace testing;
 USING_NAMESPACE_UNIT_TESTS;
 
 typedef test_mocks::SerialMock<32> SerialMock;
-typedef midi::SerialMIDI<SerialMock> Transport;
-typedef midi::MidiInterface<Transport> MidiInterface;
+typedef MIDI_NAMESPACE::SerialMIDI<SerialMock> Transport;
+typedef MIDI_NAMESPACE::MidiInterface<Transport> MidiInterface;
 
 typedef std::vector<uint8_t> Buffer;
 
@@ -29,13 +29,13 @@ TEST(MidiOutput, sendInvalid)
     MidiInterface midi((Transport&)transport);
 
     midi.begin();
-    midi.send(midi::NoteOn, 42, 42, 42);                // Invalid channel > OFF
+    midi.send(MIDI_NAMESPACE::NoteOn, 42, 42, 42);                // Invalid channel > OFF
     EXPECT_EQ(serial.mTxBuffer.getLength(), 0);
 
-    midi.send(midi::InvalidType, 0, 0, 12);             // Invalid type
+    midi.send(MIDI_NAMESPACE::InvalidType, 0, 0, 12);             // Invalid type
     EXPECT_EQ(serial.mTxBuffer.getLength(), 0);
 
-    midi.send(midi::NoteOn, 12, 42, MIDI_CHANNEL_OMNI); // OMNI not allowed
+    midi.send(MIDI_NAMESPACE::NoteOn, 12, 42, MIDI_CHANNEL_OMNI); // OMNI not allowed
     EXPECT_EQ(serial.mTxBuffer.getLength(), 0);
 }
 
@@ -49,7 +49,7 @@ TEST(MidiOutput, sendGenericSingle)
     buffer.resize(3);
 
     midi.begin();
-    midi.send(midi::NoteOn, 47, 42, 12);
+    midi.send(MIDI_NAMESPACE::NoteOn, 47, 42, 12);
     EXPECT_EQ(serial.mTxBuffer.getLength(), 3);
     serial.mTxBuffer.read(&buffer[0], 3);
     EXPECT_THAT(buffer, ElementsAreArray({0x9b, 47, 42}));
@@ -58,7 +58,7 @@ TEST(MidiOutput, sendGenericSingle)
 TEST(MidiOutput, sendGenericWithRunningStatus)
 {
     typedef VariableSettings<true, false> Settings;
-    typedef midi::MidiInterface<Transport, Settings> RsMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> RsMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -70,8 +70,8 @@ TEST(MidiOutput, sendGenericWithRunningStatus)
     midi.begin();
     EXPECT_EQ(RsMidiInterface::Settings::UseRunningStatus, true);
     EXPECT_EQ(serial.mTxBuffer.isEmpty(), true);
-    midi.send(midi::NoteOn, 47, 42, 12);
-    midi.send(midi::NoteOn, 42, 47, 12);
+    midi.send(MIDI_NAMESPACE::NoteOn, 47, 42, 12);
+    midi.send(MIDI_NAMESPACE::NoteOn, 42, 47, 12);
     EXPECT_EQ(serial.mTxBuffer.getLength(), 5);
     serial.mTxBuffer.read(&buffer[0], 5);
     EXPECT_THAT(buffer, ElementsAreArray({0x9b, 47, 42, 42, 47}));
@@ -80,7 +80,7 @@ TEST(MidiOutput, sendGenericWithRunningStatus)
 TEST(MidiOutput, sendGenericWithoutRunningStatus)
 {
     typedef VariableSettings<false, true> Settings; // No running status
-    typedef midi::MidiInterface<Transport, Settings> NoRsMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> NoRsMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -93,16 +93,16 @@ TEST(MidiOutput, sendGenericWithoutRunningStatus)
     midi.begin();
     EXPECT_EQ(MidiInterface::Settings::UseRunningStatus, false);
     EXPECT_EQ(serial.mTxBuffer.isEmpty(), true);
-    midi.send(midi::NoteOn, 47, 42, 12);
-    midi.send(midi::NoteOn, 42, 47, 12);
+    midi.send(MIDI_NAMESPACE::NoteOn, 47, 42, 12);
+    midi.send(MIDI_NAMESPACE::NoteOn, 42, 47, 12);
     EXPECT_EQ(serial.mTxBuffer.getLength(), 6);
     serial.mTxBuffer.read(&buffer[0], 6);
     EXPECT_THAT(buffer, ElementsAreArray({0x9b, 47, 42, 0x9b, 42, 47}));
 
     // Different status byte
     midi.begin();
-    midi.send(midi::NoteOn,  47, 42, 12);
-    midi.send(midi::NoteOff, 47, 42, 12);
+    midi.send(MIDI_NAMESPACE::NoteOn,  47, 42, 12);
+    midi.send(MIDI_NAMESPACE::NoteOff, 47, 42, 12);
     EXPECT_EQ(serial.mTxBuffer.getLength(), 6);
     serial.mTxBuffer.read(&buffer[0], 6);
     EXPECT_THAT(buffer, ElementsAreArray({0x9b, 47, 42, 0x8b, 47, 42}));
@@ -118,8 +118,8 @@ TEST(MidiOutput, sendGenericBreakingRunningStatus)
     buffer.resize(6);
 
     midi.begin();
-    midi.send(midi::NoteOn,  47, 42, 12);
-    midi.send(midi::NoteOff, 47, 42, 12);
+    midi.send(MIDI_NAMESPACE::NoteOn,  47, 42, 12);
+    midi.send(MIDI_NAMESPACE::NoteOff, 47, 42, 12);
     EXPECT_EQ(serial.mTxBuffer.getLength(), 6);
     serial.mTxBuffer.read(&buffer[0], 6);
     EXPECT_THAT(buffer, ElementsAreArray({0x9b, 47, 42, 0x8b, 47, 42}));
@@ -135,12 +135,12 @@ TEST(MidiOutput, sendGenericRealTimeShortcut)
     buffer.resize(6);
 
     midi.begin();
-    midi.send(midi::Clock,          47, 42, 12);
-    midi.send(midi::Start,          47, 42, 12);
-    midi.send(midi::Continue,       47, 42, 12);
-    midi.send(midi::Stop,           47, 42, 12);
-    midi.send(midi::ActiveSensing,  47, 42, 12);
-    midi.send(midi::SystemReset,    47, 42, 12);
+    midi.send(MIDI_NAMESPACE::Clock,          47, 42, 12);
+    midi.send(MIDI_NAMESPACE::Start,          47, 42, 12);
+    midi.send(MIDI_NAMESPACE::Continue,       47, 42, 12);
+    midi.send(MIDI_NAMESPACE::Stop,           47, 42, 12);
+    midi.send(MIDI_NAMESPACE::ActiveSensing,  47, 42, 12);
+    midi.send(MIDI_NAMESPACE::SystemReset,    47, 42, 12);
 
     EXPECT_EQ(serial.mTxBuffer.getLength(), 6);
     serial.mTxBuffer.read(&buffer[0], 6);
@@ -330,8 +330,8 @@ TEST(MidiOutput, sendAfterTouchPoly)
 TEST(MidiOutput, sendSysEx)
 {
     typedef test_mocks::SerialMock<1024> LargeSerialMock;
-    typedef midi::SerialMIDI<LargeSerialMock> LargeTransport;
-    typedef midi::MidiInterface<LargeTransport> LargeMidiInterface;
+    typedef MIDI_NAMESPACE::SerialMIDI<LargeSerialMock> LargeTransport;
+    typedef MIDI_NAMESPACE::MidiInterface<LargeTransport> LargeMidiInterface;
 
     LargeSerialMock serial;
     LargeTransport transport(serial);
@@ -513,12 +513,12 @@ TEST(MidiOutput, sendRealTime)
         buffer.resize(6);
 
         midi.begin();
-        midi.sendRealTime(midi::Clock);
-        midi.sendRealTime(midi::Start);
-        midi.sendRealTime(midi::Continue);
-        midi.sendRealTime(midi::Stop);
-        midi.sendRealTime(midi::ActiveSensing);
-        midi.sendRealTime(midi::SystemReset);
+        midi.sendRealTime(MIDI_NAMESPACE::Clock);
+        midi.sendRealTime(MIDI_NAMESPACE::Start);
+        midi.sendRealTime(MIDI_NAMESPACE::Continue);
+        midi.sendRealTime(MIDI_NAMESPACE::Stop);
+        midi.sendRealTime(MIDI_NAMESPACE::ActiveSensing);
+        midi.sendRealTime(MIDI_NAMESPACE::SystemReset);
 
         EXPECT_EQ(serial.mTxBuffer.getLength(), 6);
         serial.mTxBuffer.read(&buffer[0], 6);
@@ -529,19 +529,19 @@ TEST(MidiOutput, sendRealTime)
     // Test invalid messages
     {
         midi.begin();
-        midi.sendRealTime(midi::InvalidType);
-        midi.sendRealTime(midi::NoteOff);
-        midi.sendRealTime(midi::NoteOn);
-        midi.sendRealTime(midi::AfterTouchPoly);
-        midi.sendRealTime(midi::ControlChange);
-        midi.sendRealTime(midi::ProgramChange);
-        midi.sendRealTime(midi::AfterTouchChannel);
-        midi.sendRealTime(midi::PitchBend);
-        midi.sendRealTime(midi::SystemExclusive);
-        midi.sendRealTime(midi::TimeCodeQuarterFrame);
-        midi.sendRealTime(midi::SongPosition);
-        midi.sendRealTime(midi::SongSelect);
-        midi.sendRealTime(midi::TuneRequest);
+        midi.sendRealTime(MIDI_NAMESPACE::InvalidType);
+        midi.sendRealTime(MIDI_NAMESPACE::NoteOff);
+        midi.sendRealTime(MIDI_NAMESPACE::NoteOn);
+        midi.sendRealTime(MIDI_NAMESPACE::AfterTouchPoly);
+        midi.sendRealTime(MIDI_NAMESPACE::ControlChange);
+        midi.sendRealTime(MIDI_NAMESPACE::ProgramChange);
+        midi.sendRealTime(MIDI_NAMESPACE::AfterTouchChannel);
+        midi.sendRealTime(MIDI_NAMESPACE::PitchBend);
+        midi.sendRealTime(MIDI_NAMESPACE::SystemExclusive);
+        midi.sendRealTime(MIDI_NAMESPACE::TimeCodeQuarterFrame);
+        midi.sendRealTime(MIDI_NAMESPACE::SongPosition);
+        midi.sendRealTime(MIDI_NAMESPACE::SongSelect);
+        midi.sendRealTime(MIDI_NAMESPACE::TuneRequest);
 
         EXPECT_EQ(serial.mTxBuffer.getLength(), 0);
     }
@@ -550,7 +550,7 @@ TEST(MidiOutput, sendRealTime)
 TEST(MidiOutput, RPN)
 {
     typedef VariableSettings<true, true> Settings;
-    typedef midi::MidiInterface<Transport, Settings> RsMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> RsMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -668,7 +668,7 @@ TEST(MidiOutput, RPN)
 TEST(MidiOutput, NRPN)
 {
     typedef VariableSettings<true, true> Settings;
-    typedef midi::MidiInterface<Transport, Settings> RsMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> RsMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -786,7 +786,7 @@ TEST(MidiOutput, NRPN)
 TEST(MidiOutput, runningStatusCancellation)
 {
     typedef VariableSettings<true, false> Settings;
-    typedef midi::MidiInterface<Transport, Settings> RsMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> RsMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -812,7 +812,7 @@ TEST(MidiOutput, runningStatusCancellation)
         0x90, 12, 34, 56, 78
     }));
 
-    midi.sendRealTime(midi::Clock);     // Should not reset running status.
+    midi.sendRealTime(MIDI_NAMESPACE::Clock);     // Should not reset running status.
     midi.sendNoteOn(12, 34, 1);
     EXPECT_EQ(serial.mTxBuffer.getLength(), 3);
     buffer.clear();

--- a/test/unit-tests/tests/unit-tests_MidiThru.cpp
+++ b/test/unit-tests/tests/unit-tests_MidiThru.cpp
@@ -14,12 +14,12 @@ BEGIN_UNNAMED_NAMESPACE
 using namespace testing;
 USING_NAMESPACE_UNIT_TESTS
 typedef test_mocks::SerialMock<32> SerialMock;
-typedef midi::SerialMIDI<SerialMock> Transport;
-typedef midi::MidiInterface<Transport> MidiInterface;
+typedef MIDI_NAMESPACE::SerialMIDI<SerialMock> Transport;
+typedef MIDI_NAMESPACE::MidiInterface<Transport> MidiInterface;
 typedef std::vector<byte> Buffer;
 
 template<unsigned Size>
-struct VariableSysExSettings : midi::DefaultSettings
+struct VariableSysExSettings : MIDI_NAMESPACE::DefaultSettings
 {
     static const unsigned SysExMaxSize = Size;
 };
@@ -33,10 +33,10 @@ TEST(MidiThru, defaultValues)
     MidiInterface midi((Transport&)transport);
 
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::Full);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::Full);
     midi.begin(); // Should not change the state
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::Full);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::Full);
 }
 
 TEST(MidiThru, beginEnablesThru)
@@ -47,10 +47,10 @@ TEST(MidiThru, beginEnablesThru)
 
     midi.turnThruOff();
     EXPECT_EQ(midi.getThruState(),  false);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::Off);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::Off);
     midi.begin();
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::Full);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::Full);
 }
 
 TEST(MidiThru, setGet)
@@ -61,30 +61,30 @@ TEST(MidiThru, setGet)
 
     midi.turnThruOff();
     EXPECT_EQ(midi.getThruState(),  false);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::Off);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::Off);
 
     midi.turnThruOn();
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::Full);
-    midi.turnThruOn(midi::Thru::SameChannel);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::Full);
+    midi.turnThruOn(MIDI_NAMESPACE::Thru::SameChannel);
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::SameChannel);
-    midi.turnThruOn(midi::Thru::DifferentChannel);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::SameChannel);
+    midi.turnThruOn(MIDI_NAMESPACE::Thru::DifferentChannel);
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::DifferentChannel);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::DifferentChannel);
 
-    midi.setThruFilterMode(midi::Thru::Full);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::Full);
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::Full);
-    midi.setThruFilterMode(midi::Thru::SameChannel);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::Full);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::SameChannel);
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::SameChannel);
-    midi.setThruFilterMode(midi::Thru::DifferentChannel);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::SameChannel);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::DifferentChannel);
     EXPECT_EQ(midi.getThruState(),  true);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::DifferentChannel);
-    midi.setThruFilterMode(midi::Thru::Off);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::DifferentChannel);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::Off);
     EXPECT_EQ(midi.getThruState(),  false);
-    EXPECT_EQ(midi.getFilterMode(), midi::Thru::Off);
+    EXPECT_EQ(midi.getFilterMode(), MIDI_NAMESPACE::Thru::Off);
 }
 
 TEST(MidiThru, off)
@@ -117,7 +117,7 @@ TEST(MidiThru, full)
     Buffer buffer;
 
     midi.begin(MIDI_CHANNEL_OMNI);
-    midi.setThruFilterMode(midi::Thru::Full);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::Full);
 
     static const unsigned rxSize = 6;
     static const byte rxData[rxSize] = { 0x9b, 12, 34, 0x9c, 56, 78 };
@@ -161,7 +161,7 @@ TEST(MidiThru, sameChannel)
     Buffer buffer;
 
     midi.begin(12);
-    midi.setThruFilterMode(midi::Thru::SameChannel);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::SameChannel);
 
     static const unsigned rxSize = 6;
     static const byte rxData[rxSize] = { 0x9b, 12, 34, 0x9c, 56, 78 };
@@ -192,7 +192,7 @@ TEST(MidiThru, sameChannelOmni) // Acts like full
     Buffer buffer;
 
     midi.begin(MIDI_CHANNEL_OMNI);
-    midi.setThruFilterMode(midi::Thru::SameChannel);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::SameChannel);
 
     static const unsigned rxSize = 6;
     static const byte rxData[rxSize] = { 0x9b, 12, 34, 0x9c, 56, 78 };
@@ -236,7 +236,7 @@ TEST(MidiThru, differentChannel)
     Buffer buffer;
 
     midi.begin(12);
-    midi.setThruFilterMode(midi::Thru::DifferentChannel);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::DifferentChannel);
 
     static const unsigned rxSize = 6;
     static const byte rxData[rxSize] = { 0x9b, 12, 34, 0x9c, 56, 78 };
@@ -267,7 +267,7 @@ TEST(MidiThru, differentChannelOmni) // Acts like off
     Buffer buffer;
 
     midi.begin(MIDI_CHANNEL_OMNI);
-    midi.setThruFilterMode(midi::Thru::DifferentChannel);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::DifferentChannel);
 
     static const unsigned rxSize = 6;
     static const byte rxData[rxSize] = { 0x9b, 12, 34, 0x9c, 56, 78 };
@@ -291,7 +291,7 @@ TEST(MidiThru, differentChannelOmni) // Acts like off
 TEST(MidiThru, multiByteThru)
 {
     typedef VariableSettings<false, false> MultiByteParsing;
-    typedef midi::MidiInterface<Transport, MultiByteParsing> MultiByteMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, MultiByteParsing> MultiByteMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -300,7 +300,7 @@ TEST(MidiThru, multiByteThru)
     Buffer buffer;
 
     midi.begin(MIDI_CHANNEL_OMNI);
-    midi.setThruFilterMode(midi::Thru::Full);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::Full);
 
     static const unsigned rxSize = 6;
     static const byte rxData[rxSize] = { 0x9b, 12, 34, 56, 78 };
@@ -322,7 +322,7 @@ TEST(MidiThru, multiByteThru)
 TEST(MidiThru, withTxRunningStatus)
 {
     typedef VariableSettings<true, true> Settings;
-    typedef midi::MidiInterface<Transport, Settings> RsMidiInterface;
+    typedef MIDI_NAMESPACE::MidiInterface<Transport, Settings> RsMidiInterface;
 
     SerialMock serial;
     Transport transport(serial);
@@ -331,7 +331,7 @@ TEST(MidiThru, withTxRunningStatus)
     Buffer buffer;
 
     midi.begin(MIDI_CHANNEL_OMNI);
-    midi.setThruFilterMode(midi::Thru::Full);
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::Full);
 
     static const unsigned rxSize = 5;
     static const byte rxData[rxSize] = { 0x9b, 12, 34, 56, 78 };
@@ -371,7 +371,7 @@ TEST(MidiThru, invalidMode)
     MidiInterface midi((Transport&)transport);
 
     midi.begin(MIDI_CHANNEL_OMNI);
-    midi.setThruFilterMode(midi::Thru::Mode(42));
+    midi.setThruFilterMode(MIDI_NAMESPACE::Thru::Mode(42));
 
     static const unsigned rxSize = 6;
     static const byte rxData[rxSize] = { 0x9b, 12, 34, 0x9c, 56, 78 };

--- a/test/unit-tests/tests/unit-tests_Settings.cpp
+++ b/test/unit-tests/tests/unit-tests_Settings.cpp
@@ -15,10 +15,10 @@ BEGIN_UNNAMED_NAMESPACE
 
 TEST(Settings, hasTheRightDefaultValues)
 {
-    EXPECT_EQ(midi::DefaultSettings::UseRunningStatus,                   false);
-    EXPECT_EQ(midi::DefaultSettings::HandleNullVelocityNoteOnAsNoteOff,  true);
-    EXPECT_EQ(midi::DefaultSettings::Use1ByteParsing,                    true);
-    EXPECT_EQ(midi::DefaultSettings::SysExMaxSize,                       unsigned(128));
+    EXPECT_EQ(MIDI_NAMESPACE::DefaultSettings::UseRunningStatus,                   false);
+    EXPECT_EQ(MIDI_NAMESPACE::DefaultSettings::HandleNullVelocityNoteOnAsNoteOff,  true);
+    EXPECT_EQ(MIDI_NAMESPACE::DefaultSettings::Use1ByteParsing,                    true);
+    EXPECT_EQ(MIDI_NAMESPACE::DefaultSettings::SysExMaxSize,                       unsigned(128));
 }
 
 END_UNNAMED_NAMESPACE

--- a/test/unit-tests/tests/unit-tests_Settings.h
+++ b/test/unit-tests/tests/unit-tests_Settings.h
@@ -6,7 +6,7 @@
 BEGIN_UNIT_TESTS_NAMESPACE
 
 template<bool RunningStatus, bool OneByteParsing>
-struct VariableSettings : public midi::DefaultSettings
+struct VariableSettings : public MIDI_NAMESPACE::DefaultSettings
 {
     static const bool UseRunningStatus = RunningStatus;
     static const bool Use1ByteParsing  = OneByteParsing;

--- a/test/unit-tests/tests/unit-tests_SysExCodec.cpp
+++ b/test/unit-tests/tests/unit-tests_SysExCodec.cpp
@@ -16,7 +16,7 @@ TEST(SysExCodec, EncoderAscii)
     const byte input[] = "Hello, World!";
     byte buffer[16];
     memset(buffer, 0, 16 * sizeof(byte));
-    const unsigned encodedSize = midi::encodeSysEx(input, buffer, 13);
+    const unsigned encodedSize = MIDI_NAMESPACE::encodeSysEx(input, buffer, 13);
     EXPECT_EQ(encodedSize, unsigned(15));
     const byte expected[16] = {
         0, 'H', 'e', 'l', 'l', 'o', ',', ' ',
@@ -34,7 +34,7 @@ TEST(SysExCodec, EncoderNonAscii)
     };
     byte buffer[16];
     memset(buffer, 0, 16 * sizeof(byte));
-    const unsigned encodedSize = midi::encodeSysEx(input, buffer, 12);
+    const unsigned encodedSize = MIDI_NAMESPACE::encodeSysEx(input, buffer, 12);
     EXPECT_EQ(encodedSize, unsigned(14));
     const byte expected[16] = {
     //  MSB    Data
@@ -53,7 +53,7 @@ TEST(SysExCodec, EncoderNonAsciiFlipHeader)
     };
     byte buffer[16];
     memset(buffer, 0, 16 * sizeof(byte));
-    const unsigned encodedSize = midi::encodeSysEx(input, buffer, 12, true);
+    const unsigned encodedSize = MIDI_NAMESPACE::encodeSysEx(input, buffer, 12, true);
     EXPECT_EQ(encodedSize, unsigned(14));
     const byte expected[16] = {
     //  MSB    Data
@@ -74,7 +74,7 @@ TEST(SysExCodec, DecoderAscii)
     };
     byte buffer[16];
     memset(buffer, 0, 16 * sizeof(byte));
-    const unsigned decodedSize = midi::decodeSysEx(input, buffer, 15);
+    const unsigned decodedSize = MIDI_NAMESPACE::decodeSysEx(input, buffer, 15);
     EXPECT_EQ(decodedSize, unsigned(13));
     const byte expected[16] = {
         'H', 'e', 'l', 'l', 'o', ',', ' ', 'W',
@@ -94,7 +94,7 @@ TEST(SysExCodec, DecoderNonAscii)
     };
     byte buffer[16];
     memset(buffer, 0, 16 * sizeof(byte));
-    const unsigned encodedSize = midi::decodeSysEx(input, buffer, 14);
+    const unsigned encodedSize = MIDI_NAMESPACE::decodeSysEx(input, buffer, 14);
     EXPECT_EQ(encodedSize, unsigned(12));
     const byte expected[16] = {
         182, 236, 167, 177, 61, 91, 120,
@@ -114,7 +114,7 @@ TEST(SysExCodec, DecoderNonAsciiFlipHeader)
     };
     byte buffer[16];
     memset(buffer, 0, 16 * sizeof(byte));
-    const unsigned encodedSize = midi::decodeSysEx(input, buffer, 14, true);
+    const unsigned encodedSize = MIDI_NAMESPACE::decodeSysEx(input, buffer, 14, true);
     EXPECT_EQ(encodedSize, unsigned(12));
     const byte expected[16] = {
         182, 236, 167, 177, 61, 91, 120,
@@ -134,9 +134,9 @@ TEST(SysExCodec, CodecAscii)
     byte buffer2[16];
     memset(buffer1, 0, 16 * sizeof(byte));
     memset(buffer2, 0, 16 * sizeof(byte));
-    const unsigned encodedSize = midi::encodeSysEx(input, buffer1, 13);
+    const unsigned encodedSize = MIDI_NAMESPACE::encodeSysEx(input, buffer1, 13);
     EXPECT_EQ(encodedSize, unsigned(15));
-    const unsigned decodedSize = midi::decodeSysEx(buffer1, buffer2, encodedSize);
+    const unsigned decodedSize = MIDI_NAMESPACE::decodeSysEx(buffer1, buffer2, encodedSize);
     EXPECT_EQ(decodedSize, unsigned(13));
     EXPECT_STREQ(reinterpret_cast<const char*>(buffer2),
                  reinterpret_cast<const char*>(input));
@@ -153,9 +153,9 @@ TEST(SysExCodec, CodecNonAscii)
     byte buffer2[12];
     memset(buffer1, 0, 14 * sizeof(byte));
     memset(buffer2, 0, 12 * sizeof(byte));
-    const unsigned encodedSize = midi::encodeSysEx(input, buffer1, 12);
+    const unsigned encodedSize = MIDI_NAMESPACE::encodeSysEx(input, buffer1, 12);
     EXPECT_EQ(encodedSize, unsigned(14));
-    const unsigned decodedSize = midi::decodeSysEx(buffer1, buffer2, encodedSize);
+    const unsigned decodedSize = MIDI_NAMESPACE::decodeSysEx(buffer1, buffer2, encodedSize);
     EXPECT_EQ(decodedSize, unsigned(12));
     EXPECT_THAT(buffer2, ContainerEq(input));
 }
@@ -171,9 +171,9 @@ TEST(SysExCodec, CodecNonAsciiFlipHeader)
     byte buffer2[12];
     memset(buffer1, 0, 14 * sizeof(byte));
     memset(buffer2, 0, 12 * sizeof(byte));
-    const unsigned encodedSize = midi::encodeSysEx(input, buffer1, 12, true);
+    const unsigned encodedSize = MIDI_NAMESPACE::encodeSysEx(input, buffer1, 12, true);
     EXPECT_EQ(encodedSize, unsigned(14));
-    const unsigned decodedSize = midi::decodeSysEx(buffer1, buffer2, encodedSize, true);
+    const unsigned decodedSize = MIDI_NAMESPACE::decodeSysEx(buffer1, buffer2, encodedSize, true);
     EXPECT_EQ(decodedSize, unsigned(12));
     EXPECT_THAT(buffer2, ContainerEq(input));
 }


### PR DESCRIPTION
The real issue is the hardcoded one in _src/midi_Message.h_ when trying to edit the default "midi" namespace.
IMHO, if we can use custom namespace, no midi:: namespace should be hardcoded, we should instead always use the MIDI_NAMESPACE MACRO.

**I did not managed to install the unit-test to verify my modifications**, too much issues with Visual and /W argument.
If someone with a working unit-test config can verify the modifications, this would be lovely.