### PR TITLE
Fix for wrong size of message.length

### DIFF
--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -893,6 +893,7 @@ bool MidiInterface<Transport, Settings, Platform>::parse()
                 mMessage.data1   = 0;
                 mMessage.data2   = 0;
                 mMessage.valid   = true;
+                mMessage.length  = 1;
 
                 // Do not reset all input attributes, Running Status must remain unchanged.
                 // We still need to reset these
@@ -948,7 +949,7 @@ bool MidiInterface<Transport, Settings, Platform>::parse()
             mMessage.channel = getChannelFromStatusByte(mPendingMessage[0]);
             mMessage.data1   = mPendingMessage[1];
             mMessage.data2   = 0; // Completed new message has 1 data byte
-            mMessage.length  = 1;
+            mMessage.length  = 2; // Shouldn't be 1, send() checks if length > 1 to send data1, thus length needs to be 2
 
             mPendingMessageIndex = 0;
             mPendingMessageExpectedLength = 0;


### PR DESCRIPTION
Initialize message.length on first packet (don't leave it at 0) and fix for 2 packet message sizes.
I noticed that the end of message is already covered with setting message length with the mPendingMessageExpectedLength as it should, and that there's a check if the message is realtime, as send() in master branch calls getStatus() which screws up realtime midi messages (0xf8).