### PR TITLE
Parse function reworked to better deal with SysEx

### DIFF
--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -828,37 +828,29 @@ inline bool MidiInterface<Transport, Settings, Platform>::read(Channel inChannel
 
 // Private method: MIDI parser
 template<class Transport, class Settings, class Platform>
-bool MidiInterface<Transport, Settings, Platform>::parse() 
+bool MidiInterface<Transport, Settings, Platform>::parse()
 {
 
     if (mTransport.available() == 0)
         return false;
 
     mLastError &= ~(1UL << ErrorParse);  // Clear ErrorParse bit
-    /*Possible Errors:
-        > SysEx Stop byte received with no pending SysEx Start.
-        > Unsupported Status byte.
-        > Data received without a valid Status byte or Running Status.
-        > Warning SysEx split warning.
-        .... could potentially add an error for when SysEx is aborted due to receiving a new non-realtime status byte. 
-    */
 
     const byte extracted = mTransport.read();
 
     if (extracted >= 0x80) {
-        // Lets try get a valid Status byte. Non-realtime status overrides any current Status
-        const MidiType pendingType = getTypeFromStatusByte(extracted);
+        // Get Status including Undefined ones so we can properly deal with them
+        const MidiType pendingType = extracted < 0xF0 ? MidiType(extracted & 0xF0) : MidiType(extracted);
         switch (pendingType) {
-            // Realtime
+            // One byte realtime will complete now
             case Start:
             case Continue:
             case Stop:
             case Clock:
-            case Tick:
+            case Tick:  // <---- Is tick relevant anymore?? .... Not part of the MIDI spec
             case ActiveSensing:
             case SystemReset:
-            case TuneRequest:
-                // Handle message now
+                // Might as well quickly deal with these now.
                 mMessage.type = pendingType;
                 mMessage.channel = 0;
                 mMessage.data1 = 0;
@@ -866,160 +858,134 @@ bool MidiInterface<Transport, Settings, Platform>::parse()
                 mMessage.length = 1;
                 mMessage.valid = true;
                 return true;
-                break;
-                // 2 byte messages
-            case ProgramChange:
-            case AfterTouchChannel:
-            case TimeCodeQuarterFrame:
-            case SongSelect:
-                mPendingMessage[0] = extracted;
-                mPendingMessageExpectedLength = 2;
-                break;
-                // 3 byte messages
             case NoteOn:
             case NoteOff:
             case ControlChange:
             case PitchBend:
             case AfterTouchPoly:
             case SongPosition:
-                mPendingMessage[0] = extracted;
                 mPendingMessageExpectedLength = 3;
                 break;
-                // SysEx
+            case ProgramChange:
+            case AfterTouchChannel:
+            case TimeCodeQuarterFrame:
+            case SongSelect:
+                mPendingMessageExpectedLength = 2;
+                mPendingMessage[2] = 0;  // Zero unused data
+                break;
+            // One byte common will be completed this run (This will also reset running status as this is not realtime)
+            case TuneRequest:
+                mPendingMessageExpectedLength = 1;
+                mPendingMessage[1] = 0;  // Zero unused data
+                mPendingMessage[2] = 0;  // Zero unused data
+                break;
             case SystemExclusiveStart:
-                mPendingMessage[0] = SystemExclusive;
                 mPendingMessageExpectedLength = MidiMessage::sSysExMaxSize;
                 mMessage.sysexArray[0] = SystemExclusiveStart;
-                mLastError &= ~(1UL << WarningSplitSysEx);  // Reset Warning Split SysEx bit
                 break;
             case SystemExclusiveEnd:
-                if (mPendingMessage[0] == SystemExclusive) {
-                    mMessage.sysexArray[mPendingMessageIndex++] = SystemExclusiveEnd;  // Post Inc pending index here for correct length data
-                    mMessage.type = SystemExclusive;
-                    mMessage.data1 = mPendingMessageIndex & 0xff;      // LSB
-                    mMessage.data2 = byte(mPendingMessageIndex >> 8);  // MSB
-                    mMessage.channel = 0;
-                    mMessage.length = mPendingMessageIndex;
-                    if (mMessage.sysexArray[0] == SystemExclusiveEnd) {
-                        // This is the last chunk of a split SysEx message, and is NOT a valid SysEx message (it starts with 0xF7)
-                        mMessage.valid = false;  // SysEx message is split so this is not technically valid
-                        launchCallback();        // Lets notify callback to deal with this
-                        resetInput();            // Restart message
-                        return false;
-                    } else {
-                        // We are in a valid SysEx message that hasn't overrun (starts with 0xF0) so lets complete it
-                        mMessage.valid = true;
-                        resetInput();  // Restart message
-                        return true;
-                    }
-                } else {                              // Looks like a SysEx End without a Sysex Start
-                    mLastError |= 1UL << ErrorParse;  // Error: SysEx Stop byte received with no pending SysEx Start.
-                    if (mErrorCallback)
-                        mErrorCallback(mLastError);
-                    resetInput();  // Restart message
-                    return false;
+                if (mPendingMessage[0] == SystemExclusiveStart) {            // If were currently doing SysEx
+                    mPendingMessageExpectedLength = ++mPendingMessageIndex;  // Update expected lenght as we have an EOX and within Buffer
+                    break;
                 }
-                break;
-            // Unsupported
             default:
-                mPendingMessage[0] = InvalidType;
-                mLastError |= 1UL << ErrorParse;  // Error: Unsupported Status byte.
+                mLastError |= 1UL << ErrorParse;  // Error: Undefined Status or stray EOX
                 if (mErrorCallback)
                     mErrorCallback(mLastError);
-                resetInput();  // Restart message
+                if ((pendingType != Undefined_F9) && (pendingType != Undefined_FD)) {  // Dont reset for 0xFD & 0xF9 (Undefined Realtime)
+                    resetInput();                                                      // Input reset for stray EOX and Undefined common F4/F5
+                }
                 return false;
-                break;
         }
-        mPendingMessageIndex = 1;         // If we are here, we have a valid Status! Lets try get some Data for it....
-        mRunningStatus_RX = InvalidType;  // Lets also reset Running Status until we have a complete message
-        return (Settings::Use1ByteParsing) ? false : parse();
+        mRunningStatus_RX = InvalidType;                                // Reset Running Status until valid channel message complete
+        mPendingMessage[0] = extracted;                                 // Status seems good so lets store in pending
+        if (extracted != SystemExclusiveEnd) mPendingMessageIndex = 1;  // Set PendingMessageIndex to 1 (needs to be unchanged for EOX)
 
     } else {
-        // Lets get some data... First off.. check for Status Byte, or use Running Status
+        // Check Status
         if (mPendingMessageIndex == 0) {
             if (mRunningStatus_RX) {
-                // Yay! We have Running Status
                 mPendingMessage[0] = mRunningStatus_RX;
                 mPendingMessageIndex = 1;
             } else {
-                // ooops.... No Status Byte... No Running Status... lets ignore this data
-                mLastError |= 1UL << ErrorParse;  // Error: Data received without a valid Status byte or Running Status.
+                mLastError |= 1UL << ErrorParse;  // Error: No Status
                 if (mErrorCallback)
                     mErrorCallback(mLastError);
                 return false;
             }
         }
-
-        // Status or Running Status is good so add extracted data byte to pending message
+        // Add Data
         if (mPendingMessage[0] == SystemExclusive)
             mMessage.sysexArray[mPendingMessageIndex] = extracted;
         else
             mPendingMessage[mPendingMessageIndex] = extracted;
+        mPendingMessageIndex++;
+    }
+    // Check for a complete message
+    if (mPendingMessageIndex >= mPendingMessageExpectedLength) {
+        // Process SysEx
+        if (mPendingMessage[0] == SystemExclusiveStart || mPendingMessage[0] == SystemExclusiveEnd) {
 
-        // Now we are going to check if we have reached the end of the message
-        if (mPendingMessageIndex >= (mPendingMessageExpectedLength - 1)) {
-            // SysEx larger than the allocated buffer size,
+            mMessage.type = SystemExclusive;
+            mMessage.data1 = mPendingMessageIndex & 0xff;      // LSB
+            mMessage.data2 = byte(mPendingMessageIndex >> 8);  // MSB
+            mMessage.channel = 0;
+            mMessage.length = mPendingMessageIndex;
+
+            // SysEx can be larger than the allocated buffer size (must handle with callbacks only)
             // Split SysEx like so:
-            //   first:  0xF0 .... 0xF0
-            //   middle: 0xF7 .... 0xF0
-            //   last:   0xF7 .... 0xF7
-            // ***** If the buffer has overrun, this SysEx message can now no longer be considered a valid Midi message and must be dealt with via callbacks only! ****
-            if (mPendingMessage[0] == SystemExclusive) {
-                // Warn at start of SysEx split
-                if (mMessage.sysexArray[0] == SystemExclusiveStart) {
-                    mLastError |= 1UL << WarningSplitSysEx;  // We have this error already defined so may as well use it
-                    if (mErrorCallback)
-                        mErrorCallback(mLastError);
+            // first:  0xF0 .... 0xF0
+            // midlle: 0xF7 .... 0xF0
+            // last:   0xF7 .... 0xF7
+
+            // SysEx buffer not full...  EOX
+            if (mPendingMessage[0] == SystemExclusiveEnd) {
+                mMessage.sysexArray[mPendingMessageIndex - 1] = SystemExclusiveEnd;
+                mPendingMessageIndex = 0;
+                if (mMessage.sysexArray[0] == SystemExclusiveEnd) {  // This is the last chunk of split SysEx
+                    mMessage.valid = false;
+                    launchCallback();
+                } else {  // Not Split SysEx
+                    mMessage.valid = true;
                 }
-                auto lastByte = mMessage.sysexArray[Settings::SysExMaxSize - 1];
-                mMessage.sysexArray[Settings::SysExMaxSize - 1] = SystemExclusiveStart;
-                mMessage.type = SystemExclusive;
-
-                // Get length
-                mMessage.data1 = Settings::SysExMaxSize & 0xff;      // LSB
-                mMessage.data2 = byte(Settings::SysExMaxSize >> 8);  // MSB
-                mMessage.channel = 0;
-                mMessage.length = Settings::SysExMaxSize;
-                mMessage.valid = false;  // SysEx message is split so this is not technically valid
-
-                // Notify callback to deal with the SysEx data chunk
+            } else {  // SysEx buffer full
+                if (mMessage.sysexArray[0] == SystemExclusiveStart) {
+                    if (mErrorCallback)
+                        mErrorCallback(1UL << WarningSplitSysEx);  // Notify but no need to store this warning?
+                }
+                byte lastByte = mMessage.sysexArray[Settings::SysExMaxSize - 1];         // <--- change from Settings::SysExMaxSize to mPendingMessageIndex?
+                mMessage.sysexArray[Settings::SysExMaxSize - 1] = SystemExclusiveStart;  // <--- change from Settings::SysExMaxSize to mPendingMessageIndex?
+                mMessage.valid = false;
                 launchCallback();
 
                 // Prep next SysEx data chunk to start with 0xF7
                 mMessage.sysexArray[0] = SystemExclusiveEnd;
                 mMessage.sysexArray[1] = lastByte;
                 mPendingMessageIndex = 2;
-                // SysEx buffer has overrun so parse() will no longer return true, and will need to be dealt with via callbacks only
-                return false;
             }
 
-            // Pending message is complete so lets save it
-            mMessage.type = getTypeFromStatusByte(mPendingMessage[0]);
-
-            if (isChannelMessage(mMessage.type)) {
-                mMessage.channel = getChannelFromStatusByte(mPendingMessage[0]);
-                // Message will be completed soon so lets update RunningStatus now as this is obviously a valid Channel Message.
-                mRunningStatus_RX = mPendingMessage[0];
-            } else
-                mMessage.channel = 0;
-
-            mMessage.data1 = mPendingMessage[1];
-            // Save data2 only if applicable
-            mMessage.data2 = mPendingMessageExpectedLength == 3 ? mPendingMessage[2] : 0;
-            mMessage.length = mPendingMessageExpectedLength;
-            mMessage.valid = true;
-
-            // Reset index for next message
-            mPendingMessageIndex = 0;
-            //mPendingMessageExpectedLength = 0; // <-- No need to reset this as its valid still for Running Status, or will be updated on next Status byte received.
-
-            return true;
-        } else {
-            // We need more data...
-            mPendingMessageIndex++;
-
-            return (Settings::Use1ByteParsing) ? false : parse();
+            return mMessage.valid;
         }
+
+        // Process message
+        mMessage.type = getTypeFromStatusByte(mPendingMessage[0]);
+        if (isChannelMessage(mMessage.type)) {
+            mMessage.channel = (mPendingMessage[0] & 0x0F) + 1;
+            mRunningStatus_RX = mPendingMessage[0];
+        } else
+            mMessage.channel = 0;
+        mMessage.data1 = mPendingMessage[1];
+        mMessage.data2 = mPendingMessage[2];
+        mMessage.length = mPendingMessageExpectedLength;
+        mMessage.valid = true;
+
+        // Reset index for next message
+        mPendingMessageIndex = 0;
+
+        return true;
+    } else {
+        // We need more input...
+        return (Settings::Use1ByteParsing) ? false : parse();
     }
 }
 

--- a/src/MIDI.hpp
+++ b/src/MIDI.hpp
@@ -893,26 +893,20 @@ bool MidiInterface<Transport, Settings, Platform>::parse()
                 if (mErrorCallback)
                     mErrorCallback(mLastError);
                 if ((pendingType != Undefined_F9) && (pendingType != Undefined_FD)) {  // Dont reset for 0xFD & 0xF9 (Undefined Realtime)
-                    resetInput();                                                      // Input reset for stray EOX and Undefined common F4/F5
+                    mPendingMessageIndex = 0;                                          // Message reset for stray EOX and Undefined common F4/F5
                 }
                 return false;
         }
-        mRunningStatus_RX = InvalidType;                                // Reset Running Status until valid channel message complete
         mPendingMessage[0] = extracted;                                 // Status seems good so lets store in pending
         if (extracted != SystemExclusiveEnd) mPendingMessageIndex = 1;  // Set PendingMessageIndex to 1 (needs to be unchanged for EOX)
 
     } else {
         // Check Status
         if (mPendingMessageIndex == 0) {
-            if (mRunningStatus_RX) {
-                mPendingMessage[0] = mRunningStatus_RX;
-                mPendingMessageIndex = 1;
-            } else {
-                mLastError |= 1UL << ErrorParse;  // Error: No Status
-                if (mErrorCallback)
-                    mErrorCallback(mLastError);
-                return false;
-            }
+            mLastError |= 1UL << ErrorParse;  // Error: No Status
+            if (mErrorCallback)
+                mErrorCallback(mLastError);
+            return false;
         }
         // Add Data
         if (mPendingMessage[0] == SystemExclusive)
@@ -953,8 +947,8 @@ bool MidiInterface<Transport, Settings, Platform>::parse()
                     if (mErrorCallback)
                         mErrorCallback(1UL << WarningSplitSysEx);  // Notify but no need to store this warning?
                 }
-                byte lastByte = mMessage.sysexArray[Settings::SysExMaxSize - 1];         // <--- change from Settings::SysExMaxSize to mPendingMessageIndex?
-                mMessage.sysexArray[Settings::SysExMaxSize - 1] = SystemExclusiveStart;  // <--- change from Settings::SysExMaxSize to mPendingMessageIndex?
+                byte lastByte = mMessage.sysexArray[Settings::SysExMaxSize - 1];
+                mMessage.sysexArray[Settings::SysExMaxSize - 1] = SystemExclusiveStart;
                 mMessage.valid = false;
                 launchCallback();
 
@@ -968,19 +962,19 @@ bool MidiInterface<Transport, Settings, Platform>::parse()
         }
 
         // Process message
-        mMessage.type = getTypeFromStatusByte(mPendingMessage[0]);
-        if (isChannelMessage(mMessage.type)) {
+        if (mPendingMessage[0] < 0xF0) {  // Channel message
+            mMessage.type = MidiType(mPendingMessage[0] & 0xF0);
             mMessage.channel = (mPendingMessage[0] & 0x0F) + 1;
-            mRunningStatus_RX = mPendingMessage[0];
-        } else
+            mPendingMessageIndex = 1;  // Set to 1 for running status
+        } else {                       // Common message
+            mMessage.type = MidiType(mPendingMessage[0]);
             mMessage.channel = 0;
+            mPendingMessageIndex = 0;
+        }
         mMessage.data1 = mPendingMessage[1];
         mMessage.data2 = mPendingMessage[2];
         mMessage.length = mPendingMessageExpectedLength;
         mMessage.valid = true;
-
-        // Reset index for next message
-        mPendingMessageIndex = 0;
 
         return true;
     } else {


### PR DESCRIPTION
A reworking of the parse function to deal with SysEx start & stop bytes as per the Midi guidelines:

http://midi.teragonaudio.com/tech/midispec/sysex.htm#

In summary....
Non realtime Status bytes received will now abort any current SysEx message..... and SysEx stop bytes will now be ignored unless there has previously been a SysEx start byte received for the current pending message.... Also reworked how SysEx bytes are dealt with in general (Start and Stop bytes are no longer treated as the same).

This was the root cause of the Midi input becoming locked in a SysEx loop, with no route to recovery when an erroneous SysEx start or stop byte was received potentially caused by plugging in a TRS Midi connector (which can cause random garbage data), or the unlikely event of connecting Midi cables in-between a SysEx transmission. #367 

Also SysEx messages which are larger than the SysEx buffer (which will result in them being split into chunks) will no longer be considered valid Midi messages, and will have to be dealt with via callbacks only. This is to avoid malformed and incomplete SysEx messages (at the end of a split), which would be automatically transmitted if Thru mode was On. Also reintroduced the WarningSplitSysEx error which will notify when a SysEx message has overrun its buffer, and will be cleared when a fresh SysEx message has begun. 

I have tested this as much as I can with my Midi setup (Teensy 4) and all looks good, but I have not run the unit tests because I (embarrassingly) am unsure how to set them up. I've been a bit generous with the comments so hopefully the code is easy to follow.

Thanks to everyone who has previously contributed to this. For the most part this library has been pretty solid for me, and I'm happy to potentially contribute..... I'm not a professional when it comes to coding, and this is my first ever PR, (I'll be quietly chuffed if it gets taken in), but it's a fairly big change, so it's probably a good idea for others to give this one a proper check over first.